### PR TITLE
fixed shelve saving

### DIFF
--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -97,7 +97,7 @@ def control_plots(user_config_path: str):
 
         # - set up log file for each system
         # file handler
-        file_handler = utils.logging.FileHandler(plt_path + "_" + system + ".log")
+        file_handler = utils.logging.FileHandler(plt_path + "-" + system + ".log")
         file_handler.setLevel(utils.logging.DEBUG)
         # add to logger
         utils.logger.addHandler(file_handler)

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -1,5 +1,5 @@
 import shelve
-import os
+
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from pandas import DataFrame
@@ -144,14 +144,22 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
 
         # saving of param dictionary in the global dictionary that will be stored in the shelve object
         if plot_settings["event_type"] in out_dict.keys():
-            out_dict[plot_settings["event_type"]] = { plot_info["parameter"]: par_dict_content }
+            out_dict[plot_settings["event_type"]] = {
+                plot_info["parameter"]: par_dict_content
+            }
         else:
             # empty dictionary (not filled yet)
             if len(out_dict.keys()) == 0:
-                out_dict = { plot_settings["event_type"]: { plot_info["parameter"]: par_dict_content } }
+                out_dict = {
+                    plot_settings["event_type"]: {
+                        plot_info["parameter"]: par_dict_content
+                    }
+                }
             # the dictionary already contains something (but for another event type selection)
             else:
-                out_dict[plot_settings["event_type"]] = { plot_info["parameter"]: par_dict_content }
+                out_dict[plot_settings["event_type"]] = {
+                    plot_info["parameter"]: par_dict_content
+                }
 
     # save in shelve object
     out_file = shelve.open(plt_path)


### PR DESCRIPTION
Different event types (pulser,phy,all) are now saved in the same shelve object. Before, different event type entries used to be overwritten within the for loop over parameters for a given subsystem.

Now the dictionary structure is of the following type:

``` bash
l200-p02-r010-phy
     ├── pulser // only pulser events
     │   └── baseline // parameter name
     │   	├── 4 // this is the channel FC id
     │   	│	├── values // these are y plot-values shown 
     │          │       │           ├── all // every timestamp entry
     │          │       │           └── resampled // after the resampling
     │          │	├── timestamp// these are plot-x values shown 
     │          │       │           ├── all
     │          │       │           └── resampled
     │    	│ 	├── mean // mean over the first 10% of data within the range inspected by the user
     │   	│	└── plot_info // some useful plot-info: ['title', 'subsystem', 'locname', 'unit', 'plot_style', 'parameter', 'label', 'unit_label', 'time_window', 'limits']
     │   	└── ... 
     ├── phy // only non-pulser (=physical) events
     │   └── K lines
     │   	└── ...
     └── all // all events
         └── event rate
        	└── ...
```