### PR TITLE
fixed saving method + added cc4 plotting

### DIFF
--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -108,6 +108,8 @@ class AnalysisData:
             "name",
             "location",
             "position",
+            "cc4_id",
+            "cc4_channel",
             "status",
         ]
         # pulser flag is present only if subsystem.flag_pulser_events() was called

--- a/src/legend_data_monitor/plot_styles.py
+++ b/src/legend_data_monitor/plot_styles.py
@@ -13,6 +13,9 @@ from matplotlib.ticker import FixedLocator
 from pandas import DataFrame, Timedelta
 
 
+import io
+
+
 def plot_vs_time(
     data_channel: DataFrame, fig: Figure, ax: Axes, plot_info: dict, color=None
 ):
@@ -31,10 +34,12 @@ def plot_vs_time(
         color=color if plot_info["parameter"] == "event_rate" else "darkgray",
     )
 
+    # save the mean value performed over the first bunch of data
+    mean_value = data_channel[plot_info["parameter"] + "_mean"].iloc[0]
+
     # -------------------------------------------------------------------------
     # plot resampled average
     # -------------------------------------------------------------------------
-    mean_value = data_channel[plot_info["parameter"] + "_mean"].iloc[0]
 
     # unless event rate - already resampled and counted in some time window
     if not plot_info["parameter"] == "event_rate":
@@ -111,6 +116,13 @@ def plot_vs_time(
     fig.supxlabel("UTC Time")
     fig.supylabel(f"{plot_info['label']} [{plot_info['unit_label']}]")
 
+    # To save the axes, this is the only way I managed to save it without errors later on.
+    # Typically, I used to get the error: "TypeError: cannot pickle 'kiwisolver.Solver' object"
+    with io.BytesIO() as buf:
+        fig.savefig(buf, format='pdf', bbox_inches='tight')
+        buf.seek(0)
+        ch_dict['figure'] = buf.getvalue()
+
     return ch_dict
 
 
@@ -150,9 +162,24 @@ def plot_histo(
     )
 
     # -------------------------------------------------------------------------
-
     ax.set_yscale("log")
     fig.supxlabel(f"{plot_info['label']} [{plot_info['unit_label']}]")
+
+    # saving x,y data into output files 
+    ch_dict = {
+        "values": {},
+        "mean": "",
+        "plot_info": plot_info,
+        "timestamp": {},
+    }
+
+    # To save the axes
+    with io.BytesIO() as buf:
+        fig.savefig(buf, format='pdf', bbox_inches='tight')
+        buf.seek(0)
+        ch_dict['figure'] = buf.getvalue()
+
+    return ch_dict
 
 
 def plot_scatter(
@@ -176,12 +203,34 @@ def plot_scatter(
     fig.supxlabel("UTC Time")
     fig.supylabel(f"{plot_info['label']} [{plot_info['unit_label']}]")
 
+    # saving x,y data into output files 
+    ch_dict = {
+        "values": {"all": data_channel[plot_info["parameter"]], "resampled": []},
+        "mean": "",
+        "plot_info": plot_info,
+        "timestamp": {
+            "all": data_channel["datetime"].dt.to_pydatetime(),
+            "resampled": [],
+        },
+    }
+
+    # To save the axes
+    with io.BytesIO() as buf:
+        fig.savefig(buf, format='pdf', bbox_inches='tight')
+        buf.seek(0)
+        ch_dict['figure'] = buf.getvalue()
+
+    return ch_dict
+
 
 def plot_heatmap(
     data_channel: DataFrame, fig: Figure, ax: Axes, plot_info: dict, color=None
 ):
+    ch_dict = {}
+
     # here will be a function to plot a SiPM heatmap
-    pass
+
+    return ch_dict
 
 
 # -------------------------------------------------------------------------------

--- a/src/legend_data_monitor/plot_styles.py
+++ b/src/legend_data_monitor/plot_styles.py
@@ -4,6 +4,7 @@
 
 # See mapping user plot structure keywords to corresponding functions in the end of this file
 
+import io
 from math import ceil
 
 from matplotlib.axes import Axes
@@ -11,9 +12,6 @@ from matplotlib.dates import DateFormatter, date2num
 from matplotlib.figure import Figure
 from matplotlib.ticker import FixedLocator
 from pandas import DataFrame, Timedelta
-
-
-import io
 
 
 def plot_vs_time(
@@ -119,9 +117,9 @@ def plot_vs_time(
     # To save the axes, this is the only way I managed to save it without errors later on.
     # Typically, I used to get the error: "TypeError: cannot pickle 'kiwisolver.Solver' object"
     with io.BytesIO() as buf:
-        fig.savefig(buf, format='pdf', bbox_inches='tight')
+        fig.savefig(buf, format="pdf", bbox_inches="tight")
         buf.seek(0)
-        ch_dict['figure'] = buf.getvalue()
+        ch_dict["figure"] = buf.getvalue()
 
     return ch_dict
 
@@ -165,7 +163,7 @@ def plot_histo(
     ax.set_yscale("log")
     fig.supxlabel(f"{plot_info['label']} [{plot_info['unit_label']}]")
 
-    # saving x,y data into output files 
+    # saving x,y data into output files
     ch_dict = {
         "values": {},
         "mean": "",
@@ -175,9 +173,9 @@ def plot_histo(
 
     # To save the axes
     with io.BytesIO() as buf:
-        fig.savefig(buf, format='pdf', bbox_inches='tight')
+        fig.savefig(buf, format="pdf", bbox_inches="tight")
         buf.seek(0)
-        ch_dict['figure'] = buf.getvalue()
+        ch_dict["figure"] = buf.getvalue()
 
     return ch_dict
 
@@ -203,7 +201,7 @@ def plot_scatter(
     fig.supxlabel("UTC Time")
     fig.supylabel(f"{plot_info['label']} [{plot_info['unit_label']}]")
 
-    # saving x,y data into output files 
+    # saving x,y data into output files
     ch_dict = {
         "values": {"all": data_channel[plot_info["parameter"]], "resampled": []},
         "mean": "",
@@ -216,9 +214,9 @@ def plot_scatter(
 
     # To save the axes
     with io.BytesIO() as buf:
-        fig.savefig(buf, format='pdf', bbox_inches='tight')
+        fig.savefig(buf, format="pdf", bbox_inches="tight")
         buf.seek(0)
-        ch_dict['figure'] = buf.getvalue()
+        ch_dict["figure"] = buf.getvalue()
 
     return ch_dict
 

--- a/src/legend_data_monitor/settings/user_config_L200_phy_r014.json
+++ b/src/legend_data_monitor/settings/user_config_L200_phy_r014.json
@@ -14,7 +14,7 @@
       "Baselines in pulser events": {
         "parameters": "baseline",
         "event_type": "pulser",
-        "plot_structure": "per channel",
+        "plot_structure": "per string",
         "plot_style": "vs time",
         "variation": true,
         "time_window": "1H",

--- a/src/legend_data_monitor/settings/user_config_example_L200.json
+++ b/src/legend_data_monitor/settings/user_config_example_L200.json
@@ -1,5 +1,5 @@
 {
-  "output": "/data1/users/redchuk/data_monitor/dm_out",
+  "output": "/data1/users/calgaro/out_prova",
   "dataset": {
     "experiment": "L200",
     "period": "p02",
@@ -7,39 +7,18 @@
     "path": "/data1/users/marshall/prod-ref",
     "type": "phy",
     "start": "2023-01-26 04:30:00",
-    "end": "2023-01-26 07:00:00"
+    "end": "2023-01-26 05:00:00"
   },
   "subsystems": {
-    "pulser": {
-      "Pulser event rate": {
-        "parameters": "event_rate",
-        "event_type": "pulser",
-        "plot_structure": "per channel",
-        "plot_style": "vs time",
-        "time_window": "1H"
-      },
-      "AUX channel waveform maximum": {
-        "parameters": "wf_max",
-        "event_type": "all",
-        "plot_structure": "per channel",
-        "plot_style": "histogram"
-      }
-    },
     "geds": {
       "Baselines in pulser events": {
         "parameters": "baseline",
         "event_type": "pulser",
-        "plot_structure": "per channel",
+        "plot_structure": "per cc4",
         "plot_style": "vs time",
         "variation": true,
-        "time_window": "1H"
-      },
-      "K lines": {
-        "parameters": "cuspEmax_ctc_cal",
-        "event_type": "phy",
-        "cuts": "K lines",
-        "plot_structure": "per string",
-        "plot_style": "scatter"
+        "time_window": "20T",
+        "status": false
       }
     }
   }


### PR DESCRIPTION
_fixed saving method_

- axes are saved as pdf too (using ```io.BytesIO()``` method). One way to read the figures, is then the following:
``` bash
with io.BytesIO(shelf['monitoring']['all']['wf_max']['1']['figure']) as saved_fig:
        fig = plt.figure()
        fig.patch.set_facecolor('white')
        plt.imshow(plt.imread(saved_fig))
        plt.axis('off')
        plt.savefig("output.pdf",  bbox_inches='tight')
```

- saving output has been added to other functions than ```plotting.plot_per_ch()```

_added cc4 plotting_

- now you can plot separating channels by CC4 IDs saved in channel maps
- labels, for each CC4 ID, are of the following type: ```{string number}-{position in the string}-{channel FC id}-{det name}-{CC4 channel}```