### PR TITLE
several changes

### DIFF
--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -133,7 +133,7 @@ class AnalysisData:
             # the parameter does not exist
             else:
                 utils.logger.error(
-                    "\033[91m'%s' either does not exist in 'par-settings.json' or you misspelled the parameter's name. Try again.\033[0m",
+                    "\033[91m'%s' either does not exist in 'par-settings.json' or you misspelled the parameter's name. TRY AGAIN.\033[0m",
                     param,
                 )
                 exit()
@@ -141,7 +141,15 @@ class AnalysisData:
         # avoid repetition
         params_to_get = list(np.unique(params_to_get))
 
-        self.data = sub_data[params_to_get].copy()
+        # check if there are the corresponding columns in the dataframe; otherwise, exit
+        if (set(params_to_get).issubset(sub_data.columns)):
+            self.data = sub_data[params_to_get].copy()
+        else:
+            utils.logger.error(
+                "\033[91mOne/more entry/entries among %s is/are not present in the dataframe. TRY AGAIN.\033[0m",
+                params_to_get,
+            )
+            exit()
 
         # -------------------------------------------------------------------------
 

--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -20,7 +20,7 @@ def control_plots(user_config_path: str):
     # -------------------------------------------------------------------------
 
     # Format: l200-p02-{run}-{data_type} or l200-p02-timestamp1_timestamp2-{data_type}
-    # One file for all subsystems
+    # One pdf/log file for all subsystems; one common shelve object
 
     try:
         data_types = (

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -139,7 +139,7 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
         # We need to set it back otherwise status_plot.py gets crazy and everything crashes.
         data_analysis.data = data_analysis.data.reset_index()
         # saving dataframe
-        par_dict_content["df"] = data_analysis
+        par_dict_content["df_" + plot_info["subsystem"]] = data_analysis
 
         # make a special status plot
         if "status" in plot_settings and plot_settings["status"]:
@@ -152,7 +152,7 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
                     subsystem, data_analysis, plot_info, pdf
                 )
                 # saving status map figure
-                par_dict_content[plot_info["subsystem"] + "_map"] = status_fig
+                par_dict_content["map_" + plot_info["subsystem"]] = status_fig
 
         # saving PARAMETER DICT in the dictionary that will be stored in the shelve object
         # event type key is already there
@@ -546,7 +546,6 @@ def plot_per_barrel_and_position(
                 for axes in ax_row: # this is already the Axes object (no need to add ax_idx)
                     # plot one channel on each axis, ordered by position
                     data_position = data_position[data_position['channel'] == channel[col_idx]] # get only rows for a given channel
-                    print(data_position)
 
                     # plotting...
                     if data_position.empty:

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -556,7 +556,9 @@ def plot_per_barrel_and_position(
                     axes
                 ) in ax_row:  # this is already the Axes object (no need to add ax_idx)
                     # plot one channel on each axis, ordered by position
-                    data_position = data_position[data_position['channel'] == channel[col_idx]] # get only rows for a given channel
+                    data_position = data_position[
+                        data_position["channel"] == channel[col_idx]
+                    ]  # get only rows for a given channel
 
                     # plotting...
                     if data_position.empty:

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -134,6 +134,12 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
         utils.logger.debug("Plot structure: " + plot_settings["plot_structure"])
 
         par_dict_content = plot_structure(data_analysis, plot_info, pdf)
+        
+        # For some reason, after some plotting functions the index is set to "channel".
+        # We need to set it back otherwise status_plot.py gets crazy and everything crashes.
+        data_analysis.data = data_analysis.data.reset_index()
+        # saving dataframe
+        par_dict_content["df"] = data_analysis
 
         # make a special status plot
         if "status" in plot_settings and plot_settings["status"]:
@@ -142,19 +148,19 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
                     "Thresholds are not enabled for pulser! Use you own eyes to do checks there"
                 )
             else:
-                # For some reason, after some plotting functions the index is set to "channel".
-                # We need to set it back otherwise status_plot.py gets crazy and everything crashes.
-                data_analysis.data = data_analysis.data.reset_index()
                 status_fig = status_plot.status_plot(
                     subsystem, data_analysis, plot_info, pdf
                 )
+                # saving status map figure
                 par_dict_content[plot_info["subsystem"] + "_map"] = status_fig
 
-        # saving of param dictionary in the global dictionary that will be stored in the shelve object
+        # saving PARAMETER DICT in the dictionary that will be stored in the shelve object
+        # event type key is already there
         if plot_settings["event_type"] in out_dict.keys():
-            out_dict[plot_settings["event_type"]] = {
-                plot_info["parameter"]: par_dict_content
-            }
+            #  check if the parameter is already there (without this, previous inspected parameters are overwritten)
+            if plot_info["parameter"] not in out_dict[plot_settings["event_type"]].keys():
+                out_dict[plot_settings["event_type"]][plot_info["parameter"]] = par_dict_content
+        # event type key is NOT there
         else:
             # empty dictionary (not filled yet)
             if len(out_dict.keys()) == 0:
@@ -472,93 +478,114 @@ def plot_per_barrel_and_position(
     utils.logger.debug("Plot style: " + plot_info["plot_style"])
 
     par_dict = {}
-    import sys
 
-    sys.exit(1)
-
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # UNDER CONSTRUCTION!!!
 
     # re-arrange dataframe to separate location: from location=[IB-015-016] to location=[IB] & fiber=[015-016]
     data_analysis.data["fiber"] = (
-        data_analysis.data["location"].str.split().str[:-7].str.join("")
+        data_analysis.data['location'].str.split('-').str[1].str.join('') + "-" + data_analysis.data['location'].str.split('-').str[2].str.join('')
     )
     data_analysis.data["location"] = (
-        data_analysis.data["location"].str.split().str[2:].str.join("")
-    )
-
-    # --- create plot structure
-    # number of strings/fibers
-    no_location = len(data_analysis.data["location"].unique())
-    # set constrained layout to accommodate figure suptitle
-    fig, axes = plt.subplots(
-        no_location,
-        figsize=(10, no_location * 3),
-        sharex=True,
-        sharey=True,
-        constrained_layout=True,
+        data_analysis.data["location"].str.split('-').str[0].str.join('')
     )
 
     # -------------------------------------------------------------------------------
     # create label of format hardcoded for geds pX-chXXX-name
     # -------------------------------------------------------------------------------
 
-    labels = data_analysis.data.groupby("channel").first()[["name", "position"]]
+    labels = data_analysis.data.groupby("channel").first()[["name", "position", "location", "fiber"]]
     labels["channel"] = labels.index
-    labels["label"] = labels[["position", "channel", "name"]].apply(
-        lambda x: f"p{x[0]}-ch{str(x[1]).zfill(3)}-{x[2]}", axis=1
+    labels["label"] = labels[["position", "location", "fiber", "channel", "name"]].apply(
+        lambda x: f"{x[0]}-{x[1]}-{x[2]}-ch{str(x[3]).zfill(3)}-{x[4]}", axis=1
     )
     # put it in the table
     data_analysis.data = data_analysis.data.set_index("channel")
     data_analysis.data["label"] = labels["label"]
     data_analysis.data = data_analysis.data.sort_values("label")
 
-    # -------------------------------------------------------------------------------
-    # plot
-    # -------------------------------------------------------------------------------
-
     data_analysis.data = data_analysis.data.sort_values(["location", "label"])
-    # new subplot for each string
-    ax_idx = 0
+
+    # separate figure for each barrel ("location"= IB, OB)...
     for location, data_location in data_analysis.data.groupby("location"):
-        utils.logger.debug(f"... {plot_info['locname']} {location}")
+        utils.logger.debug(f"... {location} barrel")
+        # ...and position ("position"= bottom, top)
+        for position, data_position in data_location.groupby("position"):
+            utils.logger.debug(f"..... {position}")
 
-        # new color for each channel
-        col_idx = 0
-        labels = []
-        for label, data_channel in data_location.groupby("label"):
-            ch_dict = plot_style(
-                data_channel, fig, axes[ax_idx], plot_info, COLORS[col_idx]
-            )
-            labels.append(label)
-            col_idx += 1
+            # -------------------------------------------------------------------------------
+            # create plot structure: M columns, N rows with subplots for each channel
+            # -------------------------------------------------------------------------------
 
-            channel = ((label.split("-")[1]).split("ch")[-1]).lstrip("0")
-            if channel not in par_dict.keys():
-                par_dict[channel] = ch_dict
+            # number of channels in this barrel
+            if location == "IB":
+                num_rows = 3
+                num_cols = 3
+            if location == "OB":
+                num_rows = 4
+                num_cols = 5
+            # create corresponding number of subplots for each channel, set constrained layout to accommodate figure suptitle
+            fig, axes = plt.subplots(
+                nrows=num_rows,
+                ncols=num_cols,
+                figsize=(10, num_rows * 3),
+                sharex=True,
+                constrained_layout=True,
+            )  # , sharey=True)
 
-        # add grid
-        axes[ax_idx].grid("major", linestyle="--")
-        # beautification
-        axes[ax_idx].set_title(f"{plot_info['locname']} {location}")
-        axes[ax_idx].set_ylabel("")
-        axes[ax_idx].legend(labels=labels, loc="center left", bbox_to_anchor=(1, 0.5))
+            # -------------------------------------------------------------------------------
+            # plot
+            # -------------------------------------------------------------------------------
 
-        # plot the position of the two K lines
-        if plot_info["title"] == "K lines":
-            axes[ax_idx].axhline(y=1460.822, color="gray", linestyle="--")
-            axes[ax_idx].axhline(y=1524.6, color="gray", linestyle="--")
+            data_position = data_position.reset_index()
+            channel = data_position["channel"].unique()
+            det_idx = 0
+            col_idx = 0
+            labels = []
+            for ax_row in axes:
+                for axes in ax_row: # this is already the Axes object (no need to add ax_idx)
+                    # plot one channel on each axis, ordered by position
+                    data_position = data_position[data_position['channel'] == channel[col_idx]] # get only rows for a given channel
+                    print(data_position)
 
-        # plot line at 0% for variation
-        if plot_info["unit_label"] == "%":
-            axes[ax_idx].axhline(y=0, color="gray", linestyle="--")
-        ax_idx += 1
+                    # plotting...
+                    if data_position.empty:
+                        det_idx += 1
+                        continue
 
-    # -------------------------------------------------------------------------------
-    fig.suptitle(f"{plot_info['subsystem']} - {plot_info['title']}")
-    # fig.supylabel(f'{plotdata.param.label} [{plotdata.param.unit_label}]') # --> plot style
-    plt.savefig(pdf, format="pdf", bbox_inches="tight")
-    # figures are retained until explicitly closed; close to not consume too much memory
-    plt.close()
+                    ch_dict = plot_style(
+                        data_position, fig, axes, plot_info, color=COLORS[det_idx]
+                    )
+                    labels.append(data_position["label"])
+
+                    if channel[det_idx] not in par_dict.keys():
+                        par_dict[channel[det_idx]] = ch_dict
+
+                    """text = (
+                        data_position.iloc[0]["name"]
+                        + "\n"
+                        + f"channel {channel[col_idx]}\n"
+                        + f"position {t['position']}\n"
+                        + f"mean {round(t[plot_info['parameter']+'_mean'],3)} [{plot_info['unit']}]"
+                    )"""
+                    text = str(channel[col_idx])
+                    #axes.text(1.01, 0.5, text, transform=axes.transAxes)
+                    axes.set_title(label=text, loc="center")
+
+                    # add grid
+                    axes.grid("major", linestyle="--")
+                    # remove automatic y label since there will be a shared one
+                    axes.set_ylabel("")
+
+                    det_idx += 1
+                    col_idx += 1
+
+            fig.suptitle(f"{plot_info['subsystem']} - {plot_info['title']}")
+            # fig.supylabel(f'{plotdata.param.label} [{plotdata.param.unit_label}]') # --> plot style
+            plt.savefig(pdf, format="pdf", bbox_inches="tight")
+            # figures are retained until explicitly closed; close to not consume too much memory
+            plt.close()
+
     return par_dict
 
 

--- a/src/legend_data_monitor/settings/par-settings.json
+++ b/src/legend_data_monitor/settings/par-settings.json
@@ -707,6 +707,21 @@
       }
     }
   },
+  "energies": {
+    "label": "Energy",
+    "unit": "a.u.",
+    "facecol": [0.74, 0.87, 0.9],
+    "limits": {
+      "spms": {
+        "variation": [null, null],
+        "absolute": [null, null]
+      },
+      "geds": {
+        "variation": [null, null],
+        "absolute": [null, null]
+      }
+    }
+  },
   "energy_in_pe": {
     "label": "Energy",
     "unit": "P.E.",

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -282,12 +282,12 @@ class Subsystem:
                 self.data.loc[pulser_timestamps, "flag_pulser"] = True
             except KeyError:
                 utils.logger.warning(
-                    "\033[91mWarning: cannot flag pulser events, timestamps don't match!\n \
+                    "\033[93mWarning: cannot flag pulser events, timestamps don't match!\n \
                     If you are you looking at calibration data, it's not possible to flag pulser events in it this way.\n \
                     Contact the developers if you would like them to focus on advanced flagging methods.\033[0m"
                 )
                 utils.logger.warning(
-                    "\033[91m! Proceeding without pulser flag !\033[0m"
+                    "\033[93m! Proceeding without pulser flag !\033[0m"
                 )
 
         else:
@@ -302,6 +302,8 @@ class Subsystem:
             self.data.loc[pulser_timestamps, "flag_pulser"] = True
 
         self.data = self.data.reset_index()
+
+
 
     def get_channel_map(self):
         """

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -230,7 +230,6 @@ def get_query_timerange(**kwargs):
 # Plotting related functions
 # -------------------------------------------------------------------------
 
-
 def check_plot_settings(conf: dict):
     from . import plot_styles, plotting
 
@@ -401,6 +400,10 @@ def get_all_plot_parameters(subsystem: str, config: dict):
                 all_parameters.append(parameters)
             else:
                 all_parameters += parameters
+
+            # check if there is any QC entry; if so, add it to the list of parameters to load
+            if "quality_cuts" in config["subsystems"][subsystem][plot]:
+                all_parameters.append(config["subsystems"][subsystem][plot]["quality_cuts"])
 
     return all_parameters
 


### PR DESCRIPTION
After having modified the structure of the shelve object in output, it was noticed that for multiple parameters the previous inspected ones used to be overwritten during the iteration over parameters. Now this is fixed. The output object now contains also the dataframe for all channels and for a given parameter. 

The structure looks like:
``` bash

l200-p02-r010-phy
     └── monitoring
           ├── pulser // only pulser events
           │   └── baseline // parameter name
           │   	├── 4 // this is the channel FC id
           │   	│       ├── values // these are y plot-values shown 
           │    │       │     ├── all // every timestamp entry
           │    │       │     └── resampled // after the resampling
           │    │	├── timestamp// these are plot-x values shown 
           │    │       │     ├── all
           │    │       │     └── resampled
           │    │ 	├── mean // mean over the first 10% of data within the range inspected by the user
           │   	│	└── plot_info // some useful plot-info: ['title', 'subsystem', 'locname', 'unit', 'plot_style', 'parameter', 'label', 'unit_label', 'time_window', 'limits']
           │   	├── 5
           │   	│ └── ...
           │   	├── ... other individual channels...
           │   	├── df_spms // dataframe containing all spms channels for a given parameter 
           │   	├── df_geds // dataframe containing all geds channels for a given parameter 
           │   	└── map_geds // geds status map 
           └──...
``` 