### PR TITLE
added par vs ch plots

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
   - id: black-jupyter
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v0.991"
+  rev: "v1.0.1"
   hooks:
     - id: mypy
       files: src
@@ -101,7 +101,7 @@ repos:
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "v3.0.0-alpha.4"
+  rev: "v3.0.0-alpha.6"
   hooks:
     - id: prettier
       types_or: [json]

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -262,7 +262,6 @@ class AnalysisData:
                 # put channel back in
                 self.data.reset_index()
 
-
     def channel_mean(self):
         utils.logger.info("... getting channel mean")
         # series with index channel, columns of parameters containing mean of each channel;
@@ -273,8 +272,12 @@ class AnalysisData:
         # ---> for param in self.parameters:
 
         # check if the content of paramter's column is a list
-        #if isinstance(self.data.iloc[0][self.parameters[0]], list): # ---> gives problems
-        if not isinstance(self.data.iloc[0]["location"], int) and not isinstance(self.data.iloc[0]["position"], int) or "FWHM" in self.parameters : # NEW (it's a spms)
+        # if isinstance(self.data.iloc[0][self.parameters[0]], list): # ---> gives problems
+        if (
+            not isinstance(self.data.iloc[0]["location"], int)
+            and not isinstance(self.data.iloc[0]["position"], int)
+            or "FWHM" in self.parameters
+        ):  # NEW (it's a spms)
             channels = (self.data["channel"]).unique()
             channel_mean = pd.DataFrame(
                 {"channel": channels, self.parameters[0]: [None] * len(channels)}

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -251,13 +251,13 @@ class AnalysisData:
                 # put the channel back as column
                 self.data = self.data.reset_index()
             elif param == "FWHM":
-                self.data = self.data.reset_index() # doesn't change anything putting it or not .. still I don't get the right FWHM
+                self.data = self.data.reset_index() 
 
                 # calculate FWHM for each channel (substitute 'param' column with it) 
-                channel_FWHM = self.data.groupby('channel')[utils.SPECIAL_PARAMETERS[param][0]].apply(lambda x: 2.355*np.sqrt(np.mean((x-np.mean(x,axis=0))**2, axis=0))).reset_index(name='FWHM')
+                channel_fwhm = self.data.groupby('channel')[utils.SPECIAL_PARAMETERS[param][0]].apply(lambda x: 2.355*np.sqrt(np.mean((x-np.mean(x,axis=0))**2, axis=0))).reset_index(name='FWHM')
 
                 # join the calculated RMS values to the original dataframe
-                self.data = self.data.merge(channel_FWHM, on='channel')
+                self.data = self.data.merge(channel_fwhm, on='channel')
                 
                 # put channel back in
                 self.data.reset_index()

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -274,10 +274,10 @@ class AnalysisData:
         # check if the content of paramter's column is a list
         # if isinstance(self.data.iloc[0][self.parameters[0]], list): # ---> gives problems
         if (
-            not isinstance(self.data.iloc[0]["location"], int)
-            and not isinstance(self.data.iloc[0]["position"], int)
+            (not isinstance(self.data.iloc[0]["location"], np.int64)
+            and not isinstance(self.data.iloc[0]["position"], np.int64))
             or "FWHM" in self.parameters
-        ):  # NEW (it's a spms)
+        ):  # NEW (it's a spms or we are evaluating a special parameter)
             channels = (self.data["channel"]).unique()
             channel_mean = pd.DataFrame(
                 {"channel": channels, self.parameters[0]: [None] * len(channels)}

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -281,10 +281,9 @@ class AnalysisData:
         # check if the content of paramter's column is a list
         # if isinstance(self.data.iloc[0][self.parameters[0]], list): # ---> gives problems
         if (
-            (not isinstance(self.data.iloc[0]["location"], np.int64)
-            and not isinstance(self.data.iloc[0]["position"], np.int64))
-            or "FWHM" in self.parameters
-        ):  # NEW (it's a spms or we are evaluating a special parameter)
+            not isinstance(self.data.iloc[0]["location"], np.int64)
+            and not isinstance(self.data.iloc[0]["position"], np.int64)
+        ) or "FWHM" in self.parameters:  # NEW (it's a spms or we are evaluating a special parameter)
             channels = (self.data["channel"]).unique()
             channel_mean = pd.DataFrame(
                 {"channel": channels, self.parameters[0]: [None] * len(channels)}

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -251,14 +251,21 @@ class AnalysisData:
                 # put the channel back as column
                 self.data = self.data.reset_index()
             elif param == "FWHM":
-                self.data = self.data.reset_index() 
+                self.data = self.data.reset_index()
 
-                # calculate FWHM for each channel (substitute 'param' column with it) 
-                channel_fwhm = self.data.groupby('channel')[utils.SPECIAL_PARAMETERS[param][0]].apply(lambda x: 2.355*np.sqrt(np.mean((x-np.mean(x,axis=0))**2, axis=0))).reset_index(name='FWHM')
+                # calculate FWHM for each channel (substitute 'param' column with it)
+                channel_fwhm = (
+                    self.data.groupby("channel")[utils.SPECIAL_PARAMETERS[param][0]]
+                    .apply(
+                        lambda x: 2.355
+                        * np.sqrt(np.mean((x - np.mean(x, axis=0)) ** 2, axis=0))
+                    )
+                    .reset_index(name="FWHM")
+                )
 
                 # join the calculated RMS values to the original dataframe
-                self.data = self.data.merge(channel_fwhm, on='channel')
-                
+                self.data = self.data.merge(channel_fwhm, on="channel")
+
                 # put channel back in
                 self.data.reset_index()
 

--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -190,12 +190,12 @@ def generate_plots(config: dict, plt_path: str):
         # beautification of the log file
         # -------------------------------------------------------------------------
         # Read the log file into a string
-        with open(plt_path + "-" + system + ".log", 'r') as f:
+        with open(plt_path + "-" + system + ".log") as f:
             log_text = f.read()
         # Define a regular expression pattern to match escape sequences for color codes
-        pattern = re.compile(r'\033\[[0-9;]+m')
+        pattern = re.compile(r"\033\[[0-9;]+m")
         # Remove the color codes from the log text using the pattern
-        clean_text = pattern.sub('', log_text)
+        clean_text = pattern.sub("", log_text)
         # Write the cleaned text to a new file
-        with open(plt_path + "-" + system + ".log", 'w') as f:
+        with open(plt_path + "-" + system + ".log", "w") as f:
             f.write(clean_text)

--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from . import plotting, subsystem, utils
 
@@ -184,3 +185,17 @@ def generate_plots(config: dict, plt_path: str):
         plotting.make_subsystem_plots(
             subsystems[system], config["subsystems"][system], plt_path
         )
+
+        # -------------------------------------------------------------------------
+        # beautification of the log file
+        # -------------------------------------------------------------------------
+        # Read the log file into a string
+        with open(plt_path + "-" + system + ".log", 'r') as f:
+            log_text = f.read()
+        # Define a regular expression pattern to match escape sequences for color codes
+        pattern = re.compile(r'\033\[[0-9;]+m')
+        # Remove the color codes from the log text using the pattern
+        clean_text = pattern.sub('', log_text)
+        # Write the cleaned text to a new file
+        with open(plt_path + "-" + system + ".log", 'w') as f:
+            f.write(clean_text)

--- a/src/legend_data_monitor/plot_styles.py
+++ b/src/legend_data_monitor/plot_styles.py
@@ -9,12 +9,12 @@ import io
 import numpy as np
 import pandas as pd
 from matplotlib.axes import Axes
-from matplotlib.dates import date2num, num2date
-from matplotlib.dates import DateFormatter
+from matplotlib.dates import DateFormatter, date2num, num2date
 from matplotlib.figure import Figure
 from pandas import DataFrame, Timedelta
 
 from . import utils
+
 
 def plot_vs_time(
     data_channel: DataFrame, fig: Figure, ax: Axes, plot_info: dict, color=None
@@ -118,6 +118,7 @@ def plot_vs_time(
 
     return ch_dict
 
+
 def par_vs_ch(
     data_channel: DataFrame, fig: Figure, ax: Axes, plot_info: dict, color=None
 ):
@@ -126,7 +127,7 @@ def par_vs_ch(
             "\033[91mYou are trying to plot multiple values for a given channel.\nThis is not possible, there should be only one unique value! Try again.\033[0m"
         )
         return
-    
+
     # -------------------------------------------------------------------------
     # plot data vs channel ID
     # -------------------------------------------------------------------------
@@ -135,7 +136,7 @@ def par_vs_ch(
         data_channel[plot_info["parameter"]].unique()[0],
         color=color,
     )
-    
+
     # saving x,y data into output files (absolute data only)
     ch_dict = {
         "values": data_channel[plot_info["parameter"]].unique()[0],

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -278,8 +278,11 @@ def plot_per_ch(data_analysis, plot_info, pdf):
                 + "\n"
                 + f"channel {t['channel']}\n"
                 + f"position {t['position']}\n"
-                + (f"mean {round(t[plot_info['parameter']+'_mean'],3)} [{plot_info['unit']}]"
-                if t[plot_info['parameter']+'_mean'] is not None else "") # handle with care mean='None' situations
+                + (
+                    f"mean {round(t[plot_info['parameter']+'_mean'],3)} [{plot_info['unit']}]"
+                    if t[plot_info["parameter"] + "_mean"] is not None
+                    else ""
+                )  # handle with care mean='None' situations
             )
             axes[ax_idx].text(1.01, 0.5, text, transform=axes[ax_idx].transAxes)
 

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -157,7 +157,9 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
         # saving dataframe
         par_dict_content["df_" + plot_info["subsystem"]] = data_analysis
 
-        # make a special status plot
+        # -------------------------------------------------------------------------
+        # call status plot 
+        # -------------------------------------------------------------------------
         if "status" in plot_settings and plot_settings["status"]:
             if subsystem.type == "pulser":
                 utils.logger.debug(
@@ -205,7 +207,7 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
     pdf.close()
 
     utils.logger.info(
-        f"\33[92mAll plots saved in: {plt_path}-{subsystem.type}.pdf\33[0m"
+        f"All plots saved in: \33[4m{plt_path}-{subsystem.type}.pdf\33[0m"
     )
 
 

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -278,7 +278,8 @@ def plot_per_ch(data_analysis, plot_info, pdf):
                 + "\n"
                 + f"channel {t['channel']}\n"
                 + f"position {t['position']}\n"
-                + f"mean {round(t[plot_info['parameter']+'_mean'],3)} [{plot_info['unit']}]"
+                + (f"mean {round(t[plot_info['parameter']+'_mean'],3)} [{plot_info['unit']}]"
+                if t[plot_info['parameter']+'_mean'] is not None else "") # handle with care mean='None' situations
             )
             axes[ax_idx].text(1.01, 0.5, text, transform=axes[ax_idx].transAxes)
 

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -119,11 +119,15 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
         }
 
         # --- information needed for plot style
-        plot_info["parameter"] = plot_settings["parameters"]  # could be multiple in the future!
+        plot_info["parameter"] = plot_settings[
+            "parameters"
+        ]  # could be multiple in the future!
         plot_info["label"] = utils.PLOT_INFO[plot_info["parameter"]]["label"]
         # unit label should be % if variation was asked
-        plot_info["unit_label"] = ( "%" if plot_settings["variation"] else plot_info["unit"] )
-        plot_info["cuts"] = ( plot_settings["cuts"] if "cuts" in plot_settings else "" )
+        plot_info["unit_label"] = (
+            "%" if plot_settings["variation"] else plot_info["unit"]
+        )
+        plot_info["cuts"] = plot_settings["cuts"] if "cuts" in plot_settings else ""
         # time window might be needed fort he vs time function
         plot_info["time_window"] = plot_settings["time_window"]
         # threshold values are needed for status map; might be needed for plotting limits on canvas too
@@ -155,7 +159,7 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
         par_dict_content["df_" + plot_info["subsystem"]] = data_analysis
 
         # -------------------------------------------------------------------------
-        # call status plot 
+        # call status plot
         # -------------------------------------------------------------------------
         if "status" in plot_settings and plot_settings["status"]:
             if subsystem.type == "pulser":
@@ -495,7 +499,7 @@ def plot_array(data_analysis, plot_info, pdf):
 
     import matplotlib.patches as mpatches
 
-    # --- choose plot function based on user requested style 
+    # --- choose plot function based on user requested style
     plot_style = plot_styles.PLOT_STYLE[plot_info["plot_style"]]
     utils.logger.debug("Plot style: " + plot_info["plot_style"])
 
@@ -503,7 +507,7 @@ def plot_array(data_analysis, plot_info, pdf):
 
     # --- create plot structure
     fig, axes = plt.subplots(
-        1, # no of location
+        1,  # no of location
         figsize=(10, 3),
         sharex=True,
         sharey=True,
@@ -513,7 +517,9 @@ def plot_array(data_analysis, plot_info, pdf):
     # -------------------------------------------------------------------------------
     # create label of format hardcoded for geds sX-pX-chXXX-name
     # -------------------------------------------------------------------------------
-    labels = data_analysis.data.groupby("channel").first()[["name", "location", "position"]]
+    labels = data_analysis.data.groupby("channel").first()[
+        ["name", "location", "position"]
+    ]
     labels["channel"] = labels.index
     labels["label"] = labels[["location", "position", "channel", "name"]].apply(
         lambda x: f"s{x[0]}-p{x[1]}-ch{str(x[2]).zfill(3)}-{x[3]}", axis=1
@@ -539,13 +545,11 @@ def plot_array(data_analysis, plot_info, pdf):
     for location, data_location in data_analysis.data.groupby("location"):
         utils.logger.debug(f"... {plot_info['locname']} {location}")
 
-        values_per_string = []    # y values - in each string
+        values_per_string = []  # y values - in each string
         channels_per_string = []  # x values - in each string
         # group by channel
         for label, data_channel in data_location.groupby("label"):
-            ch_dict = plot_style(
-                data_channel, fig, axes, plot_info, COLORS[col_idx]
-            )
+            ch_dict = plot_style(data_channel, fig, axes, plot_info, COLORS[col_idx])
 
             channel = ((label.split("-")[2]).split("ch")[-1]).lstrip("0")
             if channel not in par_dict.keys():
@@ -557,10 +561,17 @@ def plot_array(data_analysis, plot_info, pdf):
             channels_per_string.append(int(channel))
 
         # get average of plotted parameter per string (print horizontal line)
-        avg_of_string = sum(values_per_string)/len(values_per_string)
-        axes.hlines(y=avg_of_string, xmin=min(channels_per_string), xmax=max(channels_per_string), color='k', linestyle='-', linewidth=1) 
+        avg_of_string = sum(values_per_string) / len(values_per_string)
+        axes.hlines(
+            y=avg_of_string,
+            xmin=min(channels_per_string),
+            xmax=max(channels_per_string),
+            color="k",
+            linestyle="-",
+            linewidth=1,
+        )
         utils.logger.debug(f"..... average: {round(avg_of_string, 2)}")
-        
+
         # get legend entry (print string + colour)
         legend.append(
             mpatches.Patch(
@@ -591,7 +602,7 @@ def plot_array(data_analysis, plot_info, pdf):
     axes.set_xticks(channels)
     axes.set_xticklabels(labels, fontsize=6)
     # rotate x labels
-    plt.xticks(rotation=70, ha='right')
+    plt.xticks(rotation=70, ha="right")
     # title/label
     fig.supxlabel("")
     fig.suptitle(f"{plot_info['subsystem']} - {plot_info['title']}", y=1.15)
@@ -603,10 +614,10 @@ def plot_array(data_analysis, plot_info, pdf):
     return par_dict
 
 
-
 # -------------------------------------------------------------------------------
 # SiPM specific structures
 # -------------------------------------------------------------------------------
+
 
 def plot_per_fiber_and_barrel(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
     if plot_info["subsystem"] != "spms":

--- a/src/legend_data_monitor/run.py
+++ b/src/legend_data_monitor/run.py
@@ -60,7 +60,7 @@ def main():
     parser.add_argument(
         "--version",
         action="store_true",
-        help="""Print version and exit (NOT IMPLEMENTED).""",
+        help="""Print version and exit.""",
     )
     parser.add_argument(
         "--verbose",
@@ -94,11 +94,11 @@ def main():
         legend_data_monitor.logging.setup(logging.DEBUG, logging.root)
     else:
         legend_data_monitor.logging.setup()
+    """
 
     if args.version:
-        print(legend_data_monitor.__version__)
+        legend_data_monitor.utils.logger.info("Version: %s", legend_data_monitor.__version__)
         sys.exit()
-    """
 
     args.func(args)
 

--- a/src/legend_data_monitor/run.py
+++ b/src/legend_data_monitor/run.py
@@ -97,7 +97,9 @@ def main():
     """
 
     if args.version:
-        legend_data_monitor.utils.logger.info("Version: %s", legend_data_monitor.__version__)
+        legend_data_monitor.utils.logger.info(
+            "Version: %s", legend_data_monitor.__version__
+        )
         sys.exit()
 
     args.func(args)

--- a/src/legend_data_monitor/settings/par-settings.json
+++ b/src/legend_data_monitor/settings/par-settings.json
@@ -149,6 +149,21 @@
       }
     }
   },
+  "FWHM": {
+    "label": "FWHM",
+    "unit": "keV",
+    "facecol": [0.86, 0.86, 0.86],
+    "limits": {
+      "spms": {
+        "variation": [null, null],
+        "absolute": [null, null]
+      },
+      "geds": {
+        "variation": [null, null],
+        "absolute": [null, null]
+      }
+    }
+  },
   "dt_eff": {
     "label": "dt_eff",
     "unit": "a.u.",
@@ -692,7 +707,7 @@
       }
     }
   },
-  "K_lines": {
+  "K lines": {
     "label": "Energy",
     "unit": "keV",
     "facecol": [0.94, 0.87, 0.8],

--- a/src/legend_data_monitor/settings/special-parameters.json
+++ b/src/legend_data_monitor/settings/special-parameters.json
@@ -1,5 +1,6 @@
 {
   "K lines": "cuspEmax_ctc_cal",
+  "FWHM": "cuspEmax_ctc_cal",
   "wf_max_rel": ["wf_max", "baseline"],
   "event_rate": null
 }

--- a/src/legend_data_monitor/status_plot.py
+++ b/src/legend_data_monitor/status_plot.py
@@ -4,12 +4,12 @@
 
 # See mapping user plot structure keywords to corresponding functions in the end of this file
 
+
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import seaborn as sns
 from pandas import Timedelta
-import numpy as np
-from datetime import datetime
 
 from . import utils
 
@@ -18,13 +18,9 @@ def status_plot(subsystem, data_analysis, plot_info, pdf):
     # -------------------------------------------------------------------------
     # plot a map with statuses of channels
     # -------------------------------------------------------------------------
-    utils.logger.info(
-        "\33[95m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\33[0m"
-    )
+    utils.logger.info("\33[95m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\33[0m")
     utils.logger.info("\33[95m~~~ S T A T U S  M A P : %s\33[0m", plot_info["title"])
-    utils.logger.info(
-        "\33[95m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\33[0m"
-    )
+    utils.logger.info("\33[95m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\33[0m")
 
     data_analysis = data_analysis.data.sort_values(["location", "position"])
 
@@ -92,20 +88,40 @@ def status_plot(subsystem, data_analysis, plot_info, pdf):
             if low_thr is None and high_thr is not None:
                 if (data_per_ch[plot_info["parameter"]] > high_thr).any():
                     status = 1  # -> problematic detector
-                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] > high_thr, 'datetime'].values)
+                    out_thr_datetimes = np.append(
+                        out_thr_datetimes,
+                        data_per_ch.loc[
+                            data_per_ch[plot_info["parameter"]] > high_thr, "datetime"
+                        ].values,
+                    )
 
             if low_thr is not None and high_thr is None:
                 if (data_per_ch[plot_info["parameter"]] < low_thr).any():
                     status = 1  # -> problematic detector
-                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] < low_thr, 'datetime'].values)
+                    out_thr_datetimes = np.append(
+                        out_thr_datetimes,
+                        data_per_ch.loc[
+                            data_per_ch[plot_info["parameter"]] < low_thr, "datetime"
+                        ].values,
+                    )
 
             if low_thr is not None and high_thr is not None:
                 if (data_per_ch[plot_info["parameter"]] < low_thr).any() or (
                     data_per_ch[plot_info["parameter"]] > high_thr
                 ).any():
                     status = 1  # -> problematic detector
-                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] > high_thr, 'datetime'].values)
-                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] < low_thr, 'datetime'].values)
+                    out_thr_datetimes = np.append(
+                        out_thr_datetimes,
+                        data_per_ch.loc[
+                            data_per_ch[plot_info["parameter"]] > high_thr, "datetime"
+                        ].values,
+                    )
+                    out_thr_datetimes = np.append(
+                        out_thr_datetimes,
+                        data_per_ch.loc[
+                            data_per_ch[plot_info["parameter"]] < low_thr, "datetime"
+                        ].values,
+                    )
 
             # create a new row in the new dataframe with essential info (ie: channel, name, location, position, status)
             new_row = [[channel, name, location, position, status]]
@@ -115,11 +131,19 @@ def status_plot(subsystem, data_analysis, plot_info, pdf):
             new_dataframe = pd.concat(
                 [new_dataframe, new_df], ignore_index=True, axis=0
             )
-        
+
         # print message with timestamps where the detector is out of threshold
         if len(out_thr_datetimes) != 0:
-            out_thr_datetimes = [str(time).replace("T", " ")[:-10] for time in out_thr_datetimes]
-            utils.logger.warning("\033[93mChannel %s (str. %s, pos. %s) is out of threshold at:\n%s\033[0m", channel, location, position, out_thr_datetimes)
+            out_thr_datetimes = [
+                str(time).replace("T", " ")[:-10] for time in out_thr_datetimes
+            ]
+            utils.logger.warning(
+                "\033[93mChannel %s (str. %s, pos. %s) is out of threshold at:\n%s\033[0m",
+                channel,
+                location,
+                position,
+                out_thr_datetimes,
+            )
 
     # --------------------------------------------------------------------------------------------------------------------------
     # include OFF channels and see what is their status

--- a/src/legend_data_monitor/status_plot.py
+++ b/src/legend_data_monitor/status_plot.py
@@ -8,6 +8,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 from pandas import Timedelta
+import numpy as np
+from datetime import datetime
 
 from . import utils
 
@@ -16,6 +18,13 @@ def status_plot(subsystem, data_analysis, plot_info, pdf):
     # -------------------------------------------------------------------------
     # plot a map with statuses of channels
     # -------------------------------------------------------------------------
+    utils.logger.info(
+        "\33[95m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\33[0m"
+    )
+    utils.logger.info("\33[95m~~~ S T A T U S  M A P : %s\33[0m", plot_info["title"])
+    utils.logger.info(
+        "\33[95m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\33[0m"
+    )
 
     data_analysis = data_analysis.data.sort_values(["location", "position"])
 
@@ -76,19 +85,27 @@ def status_plot(subsystem, data_analysis, plot_info, pdf):
                 data_per_ch["datetime"] + Timedelta(plot_info["time_window"]) / 2
             )
 
-        status = 0  # -> OK detector
+        status = 0  # -> OK detector (update it if it's out of threshold)
+        # get timestamp where the interval is out of threshold
+        out_thr_datetimes = np.array([], dtype="datetime64")
         if low_thr is not None or high_thr is not None:
             if low_thr is None and high_thr is not None:
                 if (data_per_ch[plot_info["parameter"]] > high_thr).any():
                     status = 1  # -> problematic detector
+                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] > high_thr, 'datetime'].values)
+
             if low_thr is not None and high_thr is None:
                 if (data_per_ch[plot_info["parameter"]] < low_thr).any():
                     status = 1  # -> problematic detector
+                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] < low_thr, 'datetime'].values)
+
             if low_thr is not None and high_thr is not None:
                 if (data_per_ch[plot_info["parameter"]] < low_thr).any() or (
                     data_per_ch[plot_info["parameter"]] > high_thr
                 ).any():
                     status = 1  # -> problematic detector
+                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] > high_thr, 'datetime'].values)
+                    out_thr_datetimes = np.append(out_thr_datetimes, data_per_ch.loc[data_per_ch[plot_info["parameter"]] < low_thr, 'datetime'].values)
 
             # create a new row in the new dataframe with essential info (ie: channel, name, location, position, status)
             new_row = [[channel, name, location, position, status]]
@@ -98,6 +115,11 @@ def status_plot(subsystem, data_analysis, plot_info, pdf):
             new_dataframe = pd.concat(
                 [new_dataframe, new_df], ignore_index=True, axis=0
             )
+        
+        # print message with timestamps where the detector is out of threshold
+        if len(out_thr_datetimes) != 0:
+            out_thr_datetimes = [str(time).replace("T", " ")[:-10] for time in out_thr_datetimes]
+            utils.logger.warning("\033[93mChannel %s (str. %s, pos. %s) is out of threshold at:\n%s\033[0m", channel, location, position, out_thr_datetimes)
 
     # --------------------------------------------------------------------------------------------------------------------------
     # include OFF channels and see what is their status


### PR DESCRIPTION
Two main new features:

1.  when out of thresholds, corresponding timestamps are printed out in the terminal. However, since we inspect resampled values while building the status map, we don't get the actual keys to remove. Typically, for the analysis, we want to remove exactly the timestamp where something bad happened (eg spike), but this is not always the case when using the resampled values. Moreover, it would be nice to save the out-of-threshold timestamps somewhere, in order to remove those events further on during the analysis.
2. there is the possibility to plot one parameter value vs  the channel ID of geds. At the moment, this works for inspecting the FWHM, grouping channels by string. In this case, the config-subsystem part looks like:
``` bash
"subsystems": {       
      "geds": {
          "FWHM in pulser events":{
              "parameters": "FWHM",
              "event_type": "pulser",
              "plot_structure": "array",
              "plot_style" : "vs ch"
          }
      }
  }
```

The output would look like this (might change a bit in the future):
<img width="897" alt="ole" src="https://user-images.githubusercontent.com/77326044/223364746-f09e58ea-2c14-4f7b-88dd-27febaf1577e.PNG">

For each string, the mean of FWHM values is evaluated (see horizontal black line) and printed out in the legend.
