### PR TITLE
bug fix for channel mean

### DIFF
--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -270,11 +270,11 @@ class AnalysisData:
                 self.data.reset_index()
 
     def channel_mean(self):
-        '''
+        """
         Get mean value of each parameter of interest in each channel in the first 10% of the dataset.
 
         Ignore in case of SiPMs, as each entry is a list of values, not a single value.
-        '''
+        """
         utils.logger.info("... getting channel mean")
         # series with index channel, columns of parameters containing mean of each channel;
         # the mean is performed over the first 10% interval of the full time range specified in the config file
@@ -311,7 +311,7 @@ class AnalysisData:
 
             # FWHM mean is meaningless -> drop (special parameter for SiPMs)
             if "FWHM" in self.parameters:
-                channel_mean.drop('FWHM', axis=1)
+                channel_mean.drop("FWHM", axis=1)
 
         # rename columns to be param_mean
         channel_mean = channel_mean.rename(

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -193,7 +193,7 @@ class Subsystem:
         query += " and (timestamp != '20230222T231553Z')"
 
         utils.logger.info(
-            "...... querying DataLoader (includes quickfix-removed faulty files for r010)"
+            "...... querying DataLoader (includes quickfix-removed faulty files)"
         )
         utils.logger.info(query)
 


### PR DESCRIPTION
Checking type of `"location"` value to be `np.int64` did not work for me (probably because outside of container), as the type was simply `int`. This resulted in a bug that the column `<parameter>_mean` was all `None` (which should be for spms, but not for geds), which in turn resulted for `NaN` values in the parameter column if `variation=True` was selected.

Changed to check if `"location"` value is a string, signifying SiPMs. Maybe need to implement `AnalysisData` knowing what type of subsystem it is from. That could make other things neater that concern differences between geds and spms.

Additionally, moved the check "if FWHM is in parameters" to later, to remove it, since "mean of FWHM" is meaningless. (note: this is just thinking that there could be separate definitions of FWHM for spms and geds anyway, so it might appear in either case, and should not be used as a check of what subsystem i.e. what type of column value we are looking at)