### PR TITLE
fixed K events parameter

### DIFF
--- a/docs/source/manuals/get_plots.rst
+++ b/docs/source/manuals/get_plots.rst
@@ -175,16 +175,15 @@ To plot events having energies within 1430 and 1575 keV (ie, around the 40K and 
 
 .. code-block:: json
 
-    "subsystems": {
-        "geds": {
+    "subsystems": {       
+      "geds": {
           "K events":{
-              "parameters": "cuspEmax_ctc_cal",
-              "event_type": "phy",
-              "cuts": "K lines",
+              "parameters": "K_events",
+              "event_type": "K_lines",
               "plot_structure": "per string",
               "plot_style" : "scatter"
-          }
         }
+      }
     }
 
 FWHM

--- a/docs/source/manuals/get_plots.rst
+++ b/docs/source/manuals/get_plots.rst
@@ -175,7 +175,7 @@ To plot events having energies within 1430 and 1575 keV (ie, around the 40K and 
 
 .. code-block:: json
 
-    "subsystems": {       
+    "subsystems": {
       "geds": {
           "K events":{
               "parameters": "K_events",

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -275,8 +275,9 @@ class AnalysisData:
                 self.data.reset_index()
             elif param == "K_events":
                 self.data = self.data.reset_index()
-                self.data = self.data.rename(columns={utils.SPECIAL_PARAMETERS[param][0]: 'K_events'})
-
+                self.data = self.data.rename(
+                    columns={utils.SPECIAL_PARAMETERS[param][0]: "K_events"}
+                )
 
     def channel_mean(self):
         """

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -110,6 +110,11 @@ class AnalysisData:
             "position",
             "cc4_id",
             "cc4_channel",
+            "daq_crate",
+            "daq_card",
+            "HV_card",
+            "HV_channel",
+            "det_type",
             "status",
         ]
         # pulser flag is present only if subsystem.flag_pulser_events() was called
@@ -118,7 +123,7 @@ class AnalysisData:
             params_to_get.append("flag_pulser")
 
         # if special parameter, get columns needed to calculate it
-        for param in self.parameters + self.cuts:
+        for param in self.parameters:
             # check if the parameter is within the par-settings.json file
             if param in utils.PLOT_INFO.keys():
                 # check if it is a special parameter
@@ -184,7 +189,7 @@ class AnalysisData:
         elif self.evt_type == "K_lines":
             utils.logger.info("... selecting K lines in physical (non-pulser) events")
             self.data = self.data[~self.data["flag_pulser"]]
-            energy = utils.SPECIAL_PARAMETERS["K_lines"][0]
+            energy = utils.SPECIAL_PARAMETERS["K_events"][0]
             self.data = self.data[
                 (self.data[energy] > 1430) & (self.data[energy] < 1575)
             ]
@@ -268,6 +273,10 @@ class AnalysisData:
 
                 # put channel back in
                 self.data.reset_index()
+            elif param == "K_events":
+                self.data = self.data.reset_index()
+                self.data = self.data.rename(columns={utils.SPECIAL_PARAMETERS[param][0]: 'K_events'})
+
 
     def channel_mean(self):
         """
@@ -312,6 +321,8 @@ class AnalysisData:
             # FWHM mean is meaningless -> drop (special parameter for SiPMs)
             if "FWHM" in self.parameters:
                 channel_mean.drop("FWHM", axis=1)
+            if "K_events" in self.parameters:
+                channel_mean.drop("K_events", axis=1)
 
         # rename columns to be param_mean
         channel_mean = channel_mean.rename(

--- a/src/legend_data_monitor/cuts.py
+++ b/src/legend_data_monitor/cuts.py
@@ -2,7 +2,18 @@ from . import utils
 
 
 def cut_k_lines(data):
-    energy = utils.SPECIAL_PARAMETERS["K lines"][0]
+    # if we are not plotting "K_events", then there is still the case were the user might want to plot a given parameter (eg. baseline)
+    # in correspondence ok K line entries. To do this, we go and look at the corresponding energy column. In particular, the energy is decided a priori in 'special-parameters.json'
+    if utils.SPECIAL_PARAMETERS["K_events"][0] in data.columns:
+        energy = utils.SPECIAL_PARAMETERS["K_events"][0]
+    # when we are plotting "K_events", then we already re-named the energy column with the parameter's name (due to how the code was built)
+    if "K_events" in data.columns:
+            energy = "K_events"
+    # if something is not properly working, exit from the code
+    else:
+        utils.logger.error("\033[91mThe cut over K lines entries is not working. Check again your subsystem options!\033[0m")
+        exit()
+
     return data[(data[energy] > 1430) & (data[energy] < 1575)]
 
 

--- a/src/legend_data_monitor/cuts.py
+++ b/src/legend_data_monitor/cuts.py
@@ -8,10 +8,12 @@ def cut_k_lines(data):
         energy = utils.SPECIAL_PARAMETERS["K_events"][0]
     # when we are plotting "K_events", then we already re-named the energy column with the parameter's name (due to how the code was built)
     if "K_events" in data.columns:
-            energy = "K_events"
+        energy = "K_events"
     # if something is not properly working, exit from the code
     else:
-        utils.logger.error("\033[91mThe cut over K lines entries is not working. Check again your subsystem options!\033[0m")
+        utils.logger.error(
+            "\033[91mThe cut over K lines entries is not working. Check again your subsystem options!\033[0m"
+        )
         exit()
 
     return data[(data[energy] > 1430) & (data[energy] < 1575)]

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -51,9 +51,6 @@ def make_subsystem_plots(subsystem: subsystem.Subsystem, plots: dict, plt_path: 
         # same, here need to account for unit label %
         if "variation" not in plot_settings:
             plot_settings["variation"] = False
-        # !? this is not needed because is checked in AnalysisData
-        # if "cuts" not in plot_settings:
-        #     plot_settings["cuts"] = []
 
         # -------------------------------------------------------------------------
         # set up analysis data
@@ -430,7 +427,7 @@ def plot_per_cc4(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
         axes[ax_idx].legend(labels=labels, loc="center left", bbox_to_anchor=(1, 0.5))
 
         # plot the position of the two K lines
-        if plot_info["cuts"] == "K lines":
+        if plot_info["parameter"] == "K_events":
             axes[ax_idx].axhline(y=1460.822, color="gray", linestyle="--")
             axes[ax_idx].axhline(y=1524.6, color="gray", linestyle="--")
 
@@ -531,7 +528,7 @@ def plot_per_string(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
         axes[ax_idx].legend(labels=labels, loc="center left", bbox_to_anchor=(1, 0.5))
 
         # plot the position of the two K lines
-        if plot_info["cuts"] == "K lines":
+        if plot_info["parameter"] == "K_events":
             axes[ax_idx].axhline(y=1460.822, color="gray", linestyle="--")
             axes[ax_idx].axhline(y=1524.6, color="gray", linestyle="--")
 

--- a/src/legend_data_monitor/settings/par-settings.json
+++ b/src/legend_data_monitor/settings/par-settings.json
@@ -10,7 +10,7 @@
       },
       "geds": {
         "variation": [-5, 5],
-        "absolute": [null, 15050]
+        "absolute": [null, null]
       }
     }
   },
@@ -707,7 +707,7 @@
       }
     }
   },
-  "K lines": {
+  "K_events": {
     "label": "Energy",
     "unit": "keV",
     "facecol": [0.94, 0.87, 0.8],

--- a/src/legend_data_monitor/settings/special-parameters.json
+++ b/src/legend_data_monitor/settings/special-parameters.json
@@ -1,5 +1,5 @@
 {
-  "K lines": "cuspEmax_ctc_cal",
+  "K_events": "cuspEmax_ctc_cal",
   "FWHM": "cuspEmax_ctc_cal",
   "wf_max_rel": ["wf_max", "baseline"],
   "event_rate": null


### PR DESCRIPTION
Simplified the "K events" plotting: now, if you want to plot only those energy events that lie in [1430,1575] keV, you have to build the following subsystem entry:

``` bash
"subsystems": {       
      "geds": {
          "K events":{
              "parameters": "K_events",
              "event_type": "K_lines",
              "plot_structure": "per string",
              "plot_style" : "scatter"
          }
      }
  }
```

```"cuts": "K lines"``` is no more needed as it was before (indeed, since we are already specifying with the ```parameters``` entry that we want to look at K events, it would be redundant to add also that cut). 

The cut over K lines entries is still an option for plotting other parameters in correspondence of K entries. However, it still does not work because in the dataframe the energy column is missing (eg. if we want to plot the ```baseline``` in correspondence of K entries, we cannot do it at the moment because the code does not know that it also has to load an energy column, which is needed for applying the energy cut). This problem was already there, and it seems it can be solved by simply loading the additional energy column if ```"cuts": "K lines"``` is present for a given parameter.