### PR TITLE
added update of the means when loading new bunch of data

### DIFF
--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -1,5 +1,8 @@
+import os
+import shelve
 import numpy as np
 import pandas as pd
+from pandas import DataFrame, concat
 
 # needed to know which parameters are not in DataLoader
 # but need to be calculated, such as event rate
@@ -51,6 +54,8 @@ class AnalysisData:
             analysis_info["variation"] = False
         if "cuts" not in analysis_info:
             analysis_info["cuts"] = []
+        if "plt_path" not in analysis_info:
+            analysis_info["saving"] = analysis_info["plt_path"] = None
 
         # convert single parameter input to list for convenience
         for input in ["parameters", "cuts"]:
@@ -96,6 +101,8 @@ class AnalysisData:
         self.time_window = analysis_info["time_window"]
         self.variation = analysis_info["variation"]
         self.cuts = analysis_info["cuts"]
+        self.saving = analysis_info["saving"]
+        self.plt_path = analysis_info["plt_path"]
 
         # -------------------------------------------------------------------------
         # subselect data
@@ -289,35 +296,71 @@ class AnalysisData:
         # series with index channel, columns of parameters containing mean of each channel;
         # the mean is performed over the first 10% interval of the full time range specified in the config file
 
-        # get mean (only for non-list parameters; in that case, add a new column with None values)
-        # ToDo: need to iterate over the parameters ??? some of them could be lists, others not
-        # ---> for param in self.parameters:
+        # get mean (only for non-list parameters; in that case, add a new column with None values):
+        # check if we are looking at SiPMs -> do not get mean because entries are usually lists
+        # ToDo: need to iterate over the parameters (some of them could be lists, others not)
 
-        # ToDo: check if the content of paramter's column is a list (can happen not only for SiPMs, but for loading waveforms)
-        # if isinstance(self.data.iloc[0][self.parameters[0]], list): # ---> gives problems
-        # check if we are looking at SiPMs -> do not get mean because entries are lists
-        if (
-            # not isinstance(self.data.iloc[0]["location"], np.int64)
-            isinstance(self.data.iloc[0]["location"], str)
-            and isinstance(self.data.iloc[0]["position"], str)
-        ):
+        # congratulations, it's a sipm! 
+        if self.is_spms():
             channels = (self.data["channel"]).unique()
             channel_mean = pd.DataFrame(
                 {"channel": channels, self.parameters[0]: [None] * len(channels)}
             )
             channel_mean = channel_mean.set_index("channel")
+        # otherwise, it's either the pulser or geds 
         else:
-            min_datetime = self.data["datetime"].min()  # first timestamp
-            max_datetime = self.data["datetime"].max()  # last timestamp
-            duration = max_datetime - min_datetime
-            ten_percent_duration = duration * 0.1
-            thr_datetime = min_datetime + ten_percent_duration  # 10% timestamp
-            # get only the rows for datetimes before the 10% of the specified time range
-            self_data_time_cut = self.data.loc[self.data["datetime"] < thr_datetime]
+            if self.saving is None or self.saving == "overwrite":
+                # get the dataframe for timestamps below 10% of data present in the selected time window
+                self_data_time_cut = cut_dataframe(self.data)
+                # create a column with the mean of the cut dataframe (cut in the time window of interest)
+                channel_mean = self_data_time_cut.groupby("channel").mean(
+                    numeric_only=True
+                )[self.parameters]
 
-            channel_mean = self_data_time_cut.groupby("channel").mean(
-                numeric_only=True
-            )[self.parameters]
+            if self.saving == "append":
+                subsys = self.get_subsys()
+                # the file does not exist, so we get the mean as usual
+                if not os.path.exists(self.plt_path + "-" + subsys + ".dat"):
+                    self_data_time_cut = cut_dataframe(self.data)
+                    # create a column with the mean of the cut dataframe (cut in the time window of interest)
+                    channel_mean = self_data_time_cut.groupby("channel").mean(
+                        numeric_only=True
+                    )[self.parameters]
+
+                # the file exist: we have to combine previous data with new data, and re-compute the mean over the first 10% of data (that now, are more than before)
+                else:
+                    # open already existing shelve file
+                    with shelve.open(self.plt_path + "-" + subsys, "r") as shelf:
+                        old_dict = dict(shelf)
+                    # get old dataframe (we are interested only in the column with mean values)
+                    old_df = old_dict["monitoring"][self.evt_type][self.parameters[0]]["df_" + subsys]
+
+                    """ 
+                    # to use in the future for a more refined version of updated mean values...
+
+                    # if previously we chose to plot % variations, we do not have anymore the absolute values to use when computing this new mean;
+                    # what we can do, is to get absolute values starting from the mean and the % values present in the old dataframe'
+                    # Later, we need to put these absolute values in the corresponding parameter column
+                    if self.variation:
+                        old_df[self.parameters[0]] = (old_df[self.parameters[0]] / 100 + 1) * old_df[self.parameters[0] + "_mean"]
+
+                    merged_df = concat([old_df, self.data], ignore_index=True, axis=0)
+                    merged_df = merged_df.reset_index()
+                    # why does this column appear? remove it in any case
+                    if "level_0" in merged_df.columns:
+                        merged_df = merged_df.drop(columns=["level_0"])  
+
+                    self_data_time_cut = cut_dataframe(merged_df)
+
+                    # ...still we have to re-compute the % variations of previous time windows because now the mean estimate is different!!!
+                    """
+                    # a column of mean values
+                    mean_df = DataFrame(old_df[self.parameters[0] + "_mean"].unique(), columns=[self.parameters[0] + "_mean"])
+                    # a column of channels
+                    channels = DataFrame(old_df["channel"].unique(), columns=["channel"])
+                    # two columns: one of channels, one of mean values
+                    channel_mean = concat([channels, mean_df], ignore_index=True, axis=1).rename(columns={0: "channel", 1: self.parameters[0] + "_mean"})
+                    channel_mean = channel_mean.set_index("channel") # it contains mean values evaluated the first time ever running this run!
 
             # FWHM mean is meaningless -> drop (special parameter for SiPMs)
             if "FWHM" in self.parameters:
@@ -331,7 +374,6 @@ class AnalysisData:
         )
         # add it as column for convenience - repeating redundant information, but convenient
         self.data = self.data.set_index("channel")
-        # self.data['mean'] = channel_mean.reindex(self.data.index)
         self.data = pd.concat(
             [self.data, channel_mean.reindex(self.data.index)], axis=1
         )
@@ -347,11 +389,44 @@ class AnalysisData:
                     self.data[param] / self.data[param + "_mean"] - 1
                 ) * 100  # %
 
-    def apply_all_cuts(self):
+    def apply_all_cuts(self) -> DataFrame:
         data_after_cuts = self.data.copy()
         for cut in self.cuts:
             data_after_cuts = cuts.apply_cut(data_after_cuts, cut)
         return data_after_cuts
+
+    def is_spms(self) -> bool:
+        """Returns True if 'location' (=fiber) and 'position' (=top, bottom) are strings."""
+        if isinstance(self.data.iloc[0]["location"], str) and isinstance(self.data.iloc[0]["position"], str):
+            return True
+        else:
+            return False
+            
+    def is_geds(self) -> bool:
+        """Returns True if 'location' (=string) and 'position' are NOT strings."""
+        if not self.is_spms():
+            return True
+        else:
+            False
+
+    def is_pulser(self) -> bool:
+        """Returns True if 'location' (=string) and 'position' are NOT strings."""
+        if self.is_geds():
+            if self.data.iloc[0]["location"] == 0 and self.data.iloc[0]["position"] == 0:
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def get_subsys(self) -> str:
+        """Returns 'pulser', 'geds' or 'spms'."""
+        if self.is_pulser():
+            return "pulser"
+        if self.is_spms():
+            return "spms"
+        if self.is_geds():
+            return "geds"
 
 
 # -------------------------------------------------------------------------
@@ -374,3 +449,16 @@ def get_seconds(time_window: str):
     time_unit = time_window[-1]
 
     return int(time_window.rstrip(time_unit)) * str_to_seconds[time_unit]
+
+
+def cut_dataframe(data: DataFrame) -> DataFrame:
+    """Get mean value of the parameters under study over the first 10% of data present in the selected time range."""
+    min_datetime = data["datetime"].min()  # first timestamp
+    max_datetime = data["datetime"].max()  # last timestamp
+    duration = max_datetime - min_datetime
+    ten_percent_duration = duration * 0.1
+    thr_datetime = min_datetime + ten_percent_duration  # 10% timestamp
+    # get only the rows for datetimes before the 10% of the specified time range
+    return data.loc[data["datetime"] < thr_datetime]
+
+

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -359,13 +359,9 @@ class AnalysisData:
                     # ...still we have to re-compute the % variations of previous time windows because now the mean estimate is different!!!
                     """
                     # a column of mean values
-                    mean_df = old_df[
-                        self.parameters[0] + "_mean"
-                    ]  
+                    mean_df = old_df[self.parameters[0] + "_mean"]
                     # a column of channels
-                    channels = old_df[
-                        "channel"
-                    ]  
+                    channels = old_df["channel"]
                     # two columns: one of channels, one of mean values
                     channel_mean = concat(
                         [channels, mean_df], ignore_index=True, axis=1

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -111,6 +111,7 @@ class AnalysisData:
 
         # always get basic parameters
         params_to_get = [
+            "timestamp",
             "datetime",
             "channel",
             "name",

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -355,14 +355,16 @@ class AnalysisData:
                     # ...still we have to re-compute the % variations of previous time windows because now the mean estimate is different!!!
                     """
                     # a column of mean values
-                    mean_df = DataFrame(old_df[self.parameters[0] + "_mean"].unique(), columns=[self.parameters[0] + "_mean"])
+                    mean_df = old_df[self.parameters[0] + "_mean"] #.groupy(self.parameters[0] + "_mean")# DataFrame(old_df[self.parameters[0] + "_mean"].unique(), columns=[self.parameters[0] + "_mean"])
                     # a column of channels
-                    channels = DataFrame(old_df["channel"].unique(), columns=["channel"])
+                    channels = old_df["channel"] #.groupy("channel")#DataFrame(old_df["channel"].unique(), columns=["channel"])
                     # two columns: one of channels, one of mean values
-                    channel_mean = concat([channels, mean_df], ignore_index=True, axis=1).rename(columns={0: "channel", 1: self.parameters[0] + "_mean"})
-                    channel_mean = channel_mean.set_index("channel") # it contains mean values evaluated the first time ever running this run!
+                    channel_mean = concat([channels, mean_df], ignore_index=True, axis=1).rename(columns={0: "channel", 1: self.parameters[0]})
+                    channel_mean = channel_mean.set_index("channel") 
+                    # drop potential duplicate rows
+                    channel_mean = channel_mean.drop_duplicates()
 
-            # FWHM mean is meaningless -> drop (special parameter for SiPMs)
+            # FWHM mean is meaningless -> drop (special parameter for SiPMs); no need to get previous mean values for these parameters
             if "FWHM" in self.parameters:
                 channel_mean.drop("FWHM", axis=1)
             if "K_events" in self.parameters:
@@ -396,21 +398,21 @@ class AnalysisData:
         return data_after_cuts
 
     def is_spms(self) -> bool:
-        """Returns True if 'location' (=fiber) and 'position' (=top, bottom) are strings."""
+        """Return True if 'location' (=fiber) and 'position' (=top, bottom) are strings."""
         if isinstance(self.data.iloc[0]["location"], str) and isinstance(self.data.iloc[0]["position"], str):
             return True
         else:
             return False
             
     def is_geds(self) -> bool:
-        """Returns True if 'location' (=string) and 'position' are NOT strings."""
+        """Return True if 'location' (=string) and 'position' are NOT strings."""
         if not self.is_spms():
             return True
         else:
             False
 
     def is_pulser(self) -> bool:
-        """Returns True if 'location' (=string) and 'position' are NOT strings."""
+        """Return True if 'location' (=string) and 'position' are NOT strings."""
         if self.is_geds():
             if self.data.iloc[0]["location"] == 0 and self.data.iloc[0]["position"] == 0:
                 return True
@@ -420,7 +422,7 @@ class AnalysisData:
             return False
 
     def get_subsys(self) -> str:
-        """Returns 'pulser', 'geds' or 'spms'."""
+        """Return 'pulser', 'geds' or 'spms'."""
         if self.is_pulser():
             return "pulser"
         if self.is_spms():

--- a/src/legend_data_monitor/plot_styles.py
+++ b/src/legend_data_monitor/plot_styles.py
@@ -88,7 +88,7 @@ def plot_vs_time(
     # --- set labels
     fig.supxlabel("UTC Time")
     y_label = (
-        f"{plot_info['label']}, {plot_info['unit_label']} [{plot_info['unit']}]"
+        f"{plot_info['label']}, {plot_info['unit_label']}"
         if plot_info["unit_label"] == "%"
         else f"{plot_info['label']} [{plot_info['unit_label']}]"
     )
@@ -134,7 +134,7 @@ def par_vs_ch(
     # --- set labels
     fig.supxlabel("Channel ID")
     y_label = (
-        f"{plot_info['label']}, {plot_info['unit_label']} [{plot_info['unit']}]"
+        f"{plot_info['label']}, {plot_info['unit_label']}"
         if plot_info["unit_label"] == "%"
         else f"{plot_info['label']} [{plot_info['unit_label']}]"
     )
@@ -181,7 +181,7 @@ def plot_histo(
     # -------------------------------------------------------------------------
     ax.set_yscale("log")
     x_label = (
-        f"{plot_info['label']}, {plot_info['unit_label']} [{plot_info['unit']}]"
+        f"{plot_info['label']}, {plot_info['unit_label']}"
         if plot_info["unit_label"] == "%"
         else f"{plot_info['label']} [{plot_info['unit_label']}]"
     )
@@ -216,7 +216,7 @@ def plot_scatter(
 
     fig.supxlabel("UTC Time")
     y_label = (
-        f"{plot_info['label']}, {plot_info['unit_label']} [{plot_info['unit']}]"
+        f"{plot_info['label']}, {plot_info['unit_label']}"
         if plot_info["unit_label"] == "%"
         else f"{plot_info['label']} [{plot_info['unit_label']}]"
     )

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -206,7 +206,7 @@ def make_subsystem_plots(
             out_dict = utils.build_out_dict(
                 plot_settings, plot_info, par_dict_content, out_dict, saving, plt_path
             )
-
+        
     # save in shelve object, overwriting the already existing file with new content (either completely new or new bunches)
     if saving is not None:
         out_file = shelve.open(plt_path + f"-{subsystem.type}")

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -53,6 +53,9 @@ def make_subsystem_plots(
         # same, here need to account for unit label %
         if "variation" not in plot_settings:
             plot_settings["variation"] = False
+        # add saving info + plot where we save things
+        plot_settings["saving"] = saving
+        plot_settings["plt_path"] = plt_path
 
         # -------------------------------------------------------------------------
         # set up analysis data

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -175,7 +175,9 @@ class Subsystem:
         time_word = list(self.timerange.keys())[0]
 
         if "start" in self.timerange[time_word]:
-            # query by (run/timestamp >= ) and (run/timestamp <=) if format {start: end:}
+            # query by (run/timestamp >= ) and (run/timestamp <=) if format {start: end:} - note: start/end have to be expressed in UTC+00 since timestamps in filenames are expressed in that format too
+            # ...this does not enter into files and get potential timestamps that enter into the selected time window;
+            # ...for the same reason, you can get timestamps over th selected time range because there is no cut in it (this can potentially be fixed later on by cutting away some rows from the dataframe)
             query = f"({time_word} >= '{self.timerange[time_word]['start']}') and ({time_word} <= '{self.timerange[time_word]['end']}')"
         else:
             # query by (run/timestamp == ) or (run/timestamp == ) if format [list of runs/timestamps]
@@ -234,8 +236,6 @@ class Subsystem:
         self.data["datetime"] = pd.to_datetime(
             self.data["timestamp"], origin="unix", utc=True, unit="s"
         )
-        # drop timestamp
-        self.data = self.data.drop("timestamp", axis=1)
 
         # -------------------------------------------------------------------------
         # add detector name, location and position from map

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -620,6 +620,8 @@ def build_out_dict(
                 # why does this column appear? remove it in any case
                 if "level_0" in merged_df.columns:
                     merged_df = merged_df.drop(columns=["level_0"]) 
+                # re-order content in order of channels/timestamps
+                merged_df = merged_df.sort_values(["channel", "datetime"])
                 
                 # redefine the dict containing the df and plot_info
                 par_dict_content = {}

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -616,10 +616,10 @@ def build_out_dict(
                 # concatenate the two dfs (channels are no more grouped; not a problem)
                 merged_df = concat([old_df, new_df], ignore_index=True, axis=0)
                 merged_df = merged_df.reset_index()
-                merged_df = merged_df.drop(
-                    columns=["level_0"]
-                )  # why does this column appear? remove it in any case
-
+                # why does this column appear? remove it in any case
+                if "level_0" in merged_df.columns:
+                    merged_df = merged_df.drop(columns=["level_0"])  
+                
                 # redefine the dict containing the df and plot_info
                 par_dict_content = {}
                 par_dict_content["df_" + plot_info["subsystem"]] = merged_df

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -619,10 +619,10 @@ def build_out_dict(
                 merged_df = merged_df.reset_index()
                 # why does this column appear? remove it in any case
                 if "level_0" in merged_df.columns:
-                    merged_df = merged_df.drop(columns=["level_0"]) 
+                    merged_df = merged_df.drop(columns=["level_0"])
                 # re-order content in order of channels/timestamps
                 merged_df = merged_df.sort_values(["channel", "datetime"])
-                
+
                 # redefine the dict containing the df and plot_info
                 par_dict_content = {}
                 par_dict_content["df_" + plot_info["subsystem"]] = merged_df

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -9,7 +9,7 @@ import shelve
 # for getting DataLoader time range
 from datetime import datetime, timedelta
 
-from pandas import concat
+from pandas import DataFrame, concat
 
 # -------------------------------------------------------------------------
 
@@ -614,11 +614,12 @@ def build_out_dict(
                 # get new df (plot_info object is the same as before, no need to get it and update it)
                 new_df = par_dict_content["df_" + plot_info["subsystem"]]
                 # concatenate the two dfs (channels are no more grouped; not a problem)
+                merged_df = DataFrame.empty
                 merged_df = concat([old_df, new_df], ignore_index=True, axis=0)
                 merged_df = merged_df.reset_index()
                 # why does this column appear? remove it in any case
                 if "level_0" in merged_df.columns:
-                    merged_df = merged_df.drop(columns=["level_0"])  
+                    merged_df = merged_df.drop(columns=["level_0"]) 
                 
                 # redefine the dict containing the df and plot_info
                 par_dict_content = {}
@@ -627,8 +628,12 @@ def build_out_dict(
 
                 # saved the merged df as usual
                 out_dict = save_dict(
-                    plot_settings, plot_info, par_dict_content, old_dict
+                    plot_settings, plot_info, par_dict_content, old_dict["monitoring"]
                 )
+                # we need to save it, otherwise when looping over the next parameter we lose the appended info for the already inspected parameter
+                out_file = shelve.open(plt_path + "-" + plot_info["subsystem"])
+                out_file["monitoring"] = out_dict
+                out_file.close()
 
     return out_dict
 
@@ -636,11 +641,7 @@ def build_out_dict(
 def save_dict(plot_settings, plot_info, par_dict_content, out_dict):
     # event type key is already there
     if plot_settings["event_type"] in out_dict.keys():
-        #  check if the parameter is already there (without this, previous inspected parameters are overwritten)
-        if plot_info["parameter"] not in out_dict[plot_settings["event_type"]].keys():
-            out_dict[plot_settings["event_type"]][
-                plot_info["parameter"]
-            ] = par_dict_content
+        out_dict[plot_settings["event_type"]][plot_info["parameter"]] = par_dict_content
     # event type key is NOT there
     else:
         # empty dictionary (not filled yet)


### PR DESCRIPTION
This new feature was implemented for situations where we want to add a bunch of new data to already processed and saved data. If previous data were saved, we read the content of that file, we get the mean previously computed over the first 10% of data of the previous inspected time range, and we re-use it in case we have to compute again % variations for a given parameter.

This feature works automatically for ```"saving": "append"```. 

Of course, the first period of data that was inspected and from which we get the means after on has to be sufficiently large to get a good estimate of the mean value of the parameter. For instance, having a pulser rate of 0.05 Hz and inspecting 6 hours of data, the mean is evaluated over ~100 pulser events.