### PR TITLE
several fixes

### DIFF
--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -349,10 +349,10 @@ class AnalysisData:
                         old_df[self.parameters[0]] = (old_df[self.parameters[0]] / 100 + 1) * old_df[self.parameters[0] + "_mean"]
 
                     merged_df = concat([old_df, self.data], ignore_index=True, axis=0)
-                    merged_df = merged_df.reset_index()
                     # why does this column appear? remove it in any case
                     if "level_0" in merged_df.columns:
                         merged_df = merged_df.drop(columns=["level_0"])
+                    merged_df = merged_df.reset_index()
 
                     self_data_time_cut = cut_dataframe(merged_df)
 

--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -61,11 +61,7 @@ def control_plots(user_config_path: str):
         return
 
     # we don't care here about the time keyword timestamp/run -> just get the value
-    plt_basename += (
-        utils.get_run_name(config, user_time_range)
-        if "timestamp" in user_time_range.keys()
-        else utils.get_time_name(user_time_range)
-    )
+    plt_basename += name_time
     plt_path = output_paths + plt_basename
     plt_path += "-{}".format("_".join(data_types))
 
@@ -73,10 +69,11 @@ def control_plots(user_config_path: str):
     generate_plots(config, plt_path)
 
 
+
 def auto_control_plots(
     plot_config: str, file_keys: str, prod_path: str, prod_config: str
 ):
-    """Set the configuration file and the output paths when a config file is provided during automathic data processing. The function to generate plots is then automatically called."""
+    """Set the configuration file and the output paths when a config file is provided during automathic plot production."""
     # -------------------------------------------------------------------------
     # Read user settings
     # -------------------------------------------------------------------------
@@ -104,7 +101,6 @@ def auto_control_plots(
             if isinstance(config["dataset"]["type"], str)
             else config["dataset"]["type"]
         )
-
         plt_basename = "{}-{}-".format(
             config["dataset"]["experiment"].lower(),
             config["dataset"]["period"],
@@ -132,7 +128,7 @@ def auto_control_plots(
         return
 
     # we don't care here about the time keyword timestamp/run -> just get the value
-    plt_basename += utils.get_time_name(user_time_range)
+    plt_basename += name_time
     plt_path = output_paths + plt_basename
     plt_path += "-{}".format("_".join(data_types))
 

--- a/src/legend_data_monitor/plot_styles.py
+++ b/src/legend_data_monitor/plot_styles.py
@@ -118,13 +118,6 @@ def par_vs_ch(
         color=color,
     )
 
-    # saving x,y data into output files (absolute data only)
-    ch_dict = {
-        "values": data_channel[plot_info["parameter"]].unique()[0],
-        "plot_info": plot_info,
-        "channel": data_channel.index.values[0],
-    }
-
     # -------------------------------------------------------------------------
     # beautification
     # -------------------------------------------------------------------------
@@ -139,8 +132,6 @@ def par_vs_ch(
         else f"{plot_info['label']} [{plot_info['unit_label']}]"
     )
     fig.supylabel(y_label)
-
-    return ch_dict
 
 
 def plot_histo(

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -570,7 +570,7 @@ def plot_array(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
         channels_per_string = []  # x values - in each string
         # group by channel
         for label, data_channel in data_location.groupby("label"):
-            ch_dict = plot_style(data_channel, fig, axes, plot_info, COLORS[col_idx])
+            plot_style(data_channel, fig, axes, plot_info, COLORS[col_idx])
 
             map_dict = utils.MAP_DICT
             location = data_channel["location"].unique()[0]
@@ -578,7 +578,7 @@ def plot_array(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
 
             labels.append(label)
             channels.append(map_dict[str(location)][str(position)])
-            values_per_string.append(ch_dict["values"])
+            values_per_string.append(data_channel[plot_info["parameter"]].unique()[0])
             channels_per_string.append(map_dict[str(location)][str(position)])
 
         # get average of plotted parameter per string (print horizontal line)

--- a/src/legend_data_monitor/run.py
+++ b/src/legend_data_monitor/run.py
@@ -111,7 +111,7 @@ def add_user_rsync_parser(subparsers):
     """Configure :func:`.core.control_rsync_plots` command line interface."""
     parser_auto_prod = subparsers.add_parser(
         "user_rsync_prod",
-        description="""Inspect LEGEND HDF5 (LH5) processed data by giving a full config file with parameters/subsystems info to plot, synching with new produced data.""",
+        description="""Inspect LEGEND HDF5 (LH5) processed data by giving a full config file with parameters/subsystems info to plot, syncing with new produced data.""",
     )
     parser_auto_prod.add_argument(
         "--config",
@@ -119,7 +119,7 @@ def add_user_rsync_parser(subparsers):
     )
     parser_auto_prod.add_argument(
         "--keys",
-        help="""Path to file contianing new keys to inspect (e.g. \"some_path/new_keys.filekeylist\").""",
+        help="""Path to file containing new keys to inspect (e.g. \"some_path/new_keys.filekeylist\").""",
     )
     parser_auto_prod.set_defaults(func=user_rsync_cli)
 

--- a/src/legend_data_monitor/run.py
+++ b/src/legend_data_monitor/run.py
@@ -62,23 +62,12 @@ def main():
         action="store_true",
         help="""Print version and exit.""",
     )
-    parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="""Increase the program verbosity (NOT IMPLEMENTED).""",
-    )
-    parser.add_argument(
-        "--debug",
-        "-d",
-        action="store_true",
-        help="""Increase the program verbosity to maximum (NOT IMPLEMENTED).""",
-    )
 
     subparsers = parser.add_subparsers()
 
     # functions for different purpouses
     add_user_config_parser(subparsers)
+    add_user_rsync_parser(subparsers)
     add_auto_prod_parser(subparsers)
 
     if len(sys.argv) < 2:
@@ -86,15 +75,6 @@ def main():
         sys.exit(1)
 
     args = parser.parse_args()
-
-    """
-    if args.verbose:
-        legend_data_monitor.logging.setup(logging.DEBUG)
-    elif args.debug:
-        legend_data_monitor.logging.setup(logging.DEBUG, logging.root)
-    else:
-        legend_data_monitor.logging.setup()
-    """
 
     if args.version:
         legend_data_monitor.utils.logger.info(
@@ -125,6 +105,36 @@ def user_config_cli(args):
 
     # start loading data & generating plots
     legend_data_monitor.core.control_plots(config_file)
+
+
+def add_user_rsync_parser(subparsers):
+    """Configure :func:`.core.control_rsync_plots` command line interface."""
+    parser_auto_prod = subparsers.add_parser(
+        "user_rsync_prod",
+        description="""Inspect LEGEND HDF5 (LH5) processed data by giving a full config file with parameters/subsystems info to plot, synching with new produced data.""",
+    )
+    parser_auto_prod.add_argument(
+        "--config",
+        help="""Path to config file (e.g. \"some_path/config_L200_r001_phy.json\").""",
+    )
+    parser_auto_prod.add_argument(
+        "--keys",
+        help="""Path to file contianing new keys to inspect (e.g. \"some_path/new_keys.filekeylist\").""",
+    )
+    parser_auto_prod.set_defaults(func=user_rsync_cli)
+
+
+def user_rsync_cli(args):
+    """Pass command line arguments to :func:`.core.control_rsync_plots`."""
+    # get the path to the user config file
+    config_file = args.config
+    keys_file = args.keys
+
+    # start loading data & generating plots
+    legend_data_monitor.core.auto_control_plots(
+        config_file, keys_file, "", {}
+    )
+
 
 
 def add_auto_prod_parser(subparsers):

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -489,7 +489,7 @@ def get_key(dsp_fname: str) -> str:
 
 
 def add_config_entries(
-    config: dict, file_keys: str, prod_path: str, prod_config: dict, saving: str
+    config: dict, file_keys: str, prod_path: str, prod_config: dict,
 ) -> dict:
     """Add missing information (output, dataset) to the configuration file. This function is generally used during automathic data production, where the initiali config file has only the 'subsystem' entry."""
     # Get the keys
@@ -497,9 +497,6 @@ def add_config_entries(
         keys = f.readlines()
     # Remove newline characters from each line using strip()
     keys = [key.strip() for key in keys]
-    # get phy/cal lists
-    phy_keys = [key for key in keys if "phy" in key]
-    cal_keys = [key for key in keys if "cal" in key]
     # get only keys of timestamps
     timestamp = [key.split("-")[-1] for key in keys]
 
@@ -509,39 +506,57 @@ def add_config_entries(
     # Get the period
     period = (keys[0].split("-"))[1]
 
-    # Get the version
-    version = (
-        (prod_path.split("/"))[-2]
-        if prod_path.endswith("/")
-        else (prod_path.split("/"))[-1]
-    )
-
     # Get the run
     run = (keys[0].split("-"))[2]
 
-    # Get the production path
-    path = (
-        prod_path.split("prod-ref")[0] + "prod-ref"
-        if prod_path.split("prod-ref")[0].endswith("/")
-        else prod_path.split("prod-ref")[0] + "/prod-ref"
-    )
-
-    # Get data type: phy, cal or [cal, phy]
-    if len(phy_keys) == 0 and len(cal_keys) == 0:
-        logger.error("\033[91mNo keys to load. Try again.\033[0m")
-        return
-    if len(phy_keys) != 0 and len(cal_keys) == 0:
-        type = "phy"
-    if len(phy_keys) == 0 and len(cal_keys) != 0:
-        type = "cal"
-        logger.error("\033[91mcal is still under development! Try again.\033[0m")
-        return
-    if len(phy_keys) != 0 and len(cal_keys) != 0:
-        type = ["cal", "phy"]
-        logger.error(
-            "\033[91mBoth cal and phy are still under development! Try again.\033[0m"
+    # Get the version
+    if "dataset" in config.keys():
+        if "version" in config["dataset"].keys():
+            version = config["dataset"]["version"]
+        else:
+            version = (
+                (prod_path.split("/"))[-2]
+                if prod_path.endswith("/")
+                else (prod_path.split("/"))[-1]
+            )
+        if "type" in config["dataset"].keys():
+            type = config["dataset"]["type"]
+        else:
+            logger.error("\033[91mYou need to provide data type! Try again.\033[0m")
+            exit()
+        if "path" in config["dataset"].keys():
+            path = config["dataset"]["path"]
+        else:
+            logger.error("\033[91mYou need to provide path to lh5 files! Try again.\033[0m")
+            exit()
+    else:
+        # get phy/cal lists
+        phy_keys = [key for key in keys if "phy" in key]
+        cal_keys = [key for key in keys if "cal" in key]
+        if len(phy_keys) == 0 and len(cal_keys) == 0:
+            logger.error("\033[91mNo keys to load. Try again.\033[0m")
+            return
+        if len(phy_keys) != 0 and len(cal_keys) == 0:
+            type = "phy"
+        if len(phy_keys) == 0 and len(cal_keys) != 0:
+            type = "cal"
+            logger.error("\033[91mcal is still under development! Try again.\033[0m")
+            return
+        if len(phy_keys) != 0 and len(cal_keys) != 0:
+            type = ["cal", "phy"]
+            logger.error(
+                "\033[91mBoth cal and phy are still under development! Try again.\033[0m"
+            )
+            return
+        # Get the production path
+        path = (
+            prod_path.split("prod-ref")[0] + "prod-ref"
+            if prod_path.split("prod-ref")[0].endswith("/")
+            else prod_path.split("prod-ref")[0] + "/prod-ref"
         )
-        return
+
+    if "output" in config.keys():
+        prod_path = config["output"]
 
     # create the dataset dictionary
     dataset_dict = {
@@ -562,11 +577,12 @@ def add_config_entries(
     # let's make a check that everything we need is inside the config, otherwise exit
     if not all(key in config for key in ["output", "dataset", "saving", "subsystems"]):
         logger.error(
-            '\033[91mThere are missing entries in the config file. Try again and check you start with "output" and "dataset" info!\033[0m'
+            '\033[91mThere are missing entries among ["output", "dataset", "saving", "subsystems"] in the config file (found keys: %s). Try again and check you start with "output" and "dataset" info!\033[0m', config.keys()
         )
         exit()
 
     return config
+
 
 
 # -------------------------------------------------------------------------
@@ -591,9 +607,9 @@ def build_out_dict(
     if saving == "append":
         # the file does not exist, so first we create it and then, at the next step, we'll append things
         if not os.path.exists(plt_path + "-" + plot_info["subsystem"] + ".dat"):
-            logger.warning(
-                "\033[93mYou selected 'append' when saving, but the file with already saved data does not exist. For this reason, it will be created first.\033[0m"
-            )
+            #logger.warning(
+            #    "\033[93mYou selected 'append' when saving, but the file with already saved data does not exist. For this reason, it will be created first.\033[0m"
+            #)
             out_dict = save_dict(plot_settings, plot_info, par_dict_content, out_dict)
 
         # the file exists, so we are going to append data
@@ -616,10 +632,10 @@ def build_out_dict(
                 # concatenate the two dfs (channels are no more grouped; not a problem)
                 merged_df = DataFrame.empty
                 merged_df = concat([old_df, new_df], ignore_index=True, axis=0)
-                merged_df = merged_df.reset_index()
                 # why does this column appear? remove it in any case
                 if "level_0" in merged_df.columns:
                     merged_df = merged_df.drop(columns=["level_0"])
+                merged_df = merged_df.reset_index()
                 # re-order content in order of channels/timestamps
                 merged_df = merged_df.sort_values(["channel", "datetime"])
 


### PR DESCRIPTION
## Synchornized monitoring plot  production
In ```run.py```, there is the new parser ```user_rsync_prod``` to be used when an user wants to synchronize the generation of plots with the processing and production of new lh5 data. 

The user has to provide the path to a config file of the following type:

``` bash
{
  "output": "/data1/users/calgaro/out_prova",
  "dataset": {
    "version": "",
    "path": "/data2/public/prodenv/prod-blind/tmp/auto",
    "type": "phy"
  },
  "saving": "append",
  "subsystems": {
    "geds": {
      "Baselines (%) in pulser events": {
        "parameters": "baseline",
        "event_type": "pulser",
        "plot_structure": "per channel",
        "resampled": "also",
        "plot_style": "vs time",
        "variation": true,
        "time_window": "1H",
        "status": true
      }
    }
  }
}
```
You also have to provide the path to a file containing a list of keys with the format ```l200-p02-r006-cal-20221226T214214Z``` for files that still need to be analyzed (since new from latest time the production folder was checked).

## Other changes

- fixed ```reset_index()``` to merged dataframe when the ```level_0``` column appears
- shortened name files in ```core.py```
- removed returning of ```ch_dict``` in ```plotting.plot_array()``` and ```plot_styles.par_vs_ch()``` (not useful at all - all necessary info are already saved in the shelve object, through the dataframe)
- changed ```utils.add_config_entries()``` to include the ```user_rsync_prod``` case in which we need to add timestamps to keep to the ```dataset``` config entry, together with experiment/period/... info