### PR TITLE
added selection of FC_bsln&muon events

### DIFF
--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -61,7 +61,7 @@ class AnalysisData:
 
         event_type_flags = {
             "pulser": ("flag_pulser", "pulser"),
-            "FC_bsln": ("flag_FC_bsln", "FC_bsln"),
+            "FC_bsln": ("flag_fc_bsln", "FC_bsln"),
             "muon": ("flag_muon", "muon")
         }
 
@@ -118,7 +118,7 @@ class AnalysisData:
 
         for col in sub_data.columns:
             # pulser flag is present only if subsystem.flag_pulser_events() was called -> needed to subselect phy/pulser events
-            if "flag_pulser" in col or "flag_FC_bsln" in col or "flag_muon" in col:
+            if "flag_pulser" in col or "flag_fc_bsln" in col or "flag_muon" in col:
                 params_to_get.append(col)
             # QC flag is present only if inserted as a cut in the config file -> this part is needed to apply
             if "is_" in col:
@@ -188,7 +188,7 @@ class AnalysisData:
             self.data = self.data[self.data["flag_pulser"]]
         elif self.evt_type == "FC_bsln":
             utils.logger.info("... keeping only FC baseline events")
-            self.data = self.data[self.data["flag_FC_bsln"]]
+            self.data = self.data[self.data["flag_fc_bsln"]]
         elif self.evt_type == "muon":
             utils.logger.info("... keeping only muon events")
             self.data = self.data[self.data["flag_muon"]]

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -62,7 +62,7 @@ class AnalysisData:
         event_type_flags = {
             "pulser": ("flag_pulser", "pulser"),
             "FC_bsln": ("flag_fc_bsln", "FC_bsln"),
-            "muon": ("flag_muon", "muon")
+            "muon": ("flag_muon", "muon"),
         }
 
         event_type = analysis_info["event_type"]

--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -59,15 +59,23 @@ class AnalysisData:
             if isinstance(analysis_info[input], str):
                 analysis_info[input] = [analysis_info[input]]
 
-        if analysis_info["event_type"] != "all" and "flag_pulser" not in sub_data:
-            utils.logger.error(
-                f"\033[91mYour subsystem data does not have a pulser flag! We need it to subselect event type {analysis_info['event_type']}\033[0m"
-            )
-            utils.logger.error(
-                "\033[91mRun the function <subsystem>.flag_pulser_events(<pulser>) first, where <subsystem> is your Subsystem object, \033[0m"
-                + "\033[91mand <pulser> is a Subsystem object of type 'pulser', which already has it data loaded with <pulser>.get_data(); then create AnalysisData object.\033[0m"
-            )
-            return
+        event_type_flags = {
+            "pulser": ("flag_pulser", "pulser"),
+            "FC_bsln": ("flag_FC_bsln", "FC_bsln"),
+            "muon": ("flag_muon", "muon")
+        }
+
+        event_type = analysis_info["event_type"]
+
+        if event_type in event_type_flags:
+            flag, subsystem_name = event_type_flags[event_type]
+            if flag not in sub_data:
+                utils.logger.error(
+                    f"\033[91mYour subsystem data does not have a {subsystem_name} flag! We need it to subselect event type {event_type}\033[0m"
+                    + f"\033[91mRun the function <subsystem>.flag_{subsystem_name}_events(<{subsystem_name}>) first, where <subsystem> is your Subsystem object, \033[0m"
+                    + f"\033[91mand <{subsystem_name}> is a Subsystem object of type '{subsystem_name}', which already has its data loaded with <{subsystem_name}>.get_data(); then create an AnalysisData object.\033[0m"
+                )
+                return
 
         # cannot do event rate and another parameter at the same time
         # since event rate is calculated in windows
@@ -110,7 +118,7 @@ class AnalysisData:
 
         for col in sub_data.columns:
             # pulser flag is present only if subsystem.flag_pulser_events() was called -> needed to subselect phy/pulser events
-            if "flag_pulser" in col:
+            if "flag_pulser" in col or "flag_FC_bsln" in col or "flag_muon" in col:
                 params_to_get.append(col)
             # QC flag is present only if inserted as a cut in the config file -> this part is needed to apply
             if "is_" in col:
@@ -178,6 +186,12 @@ class AnalysisData:
         if self.evt_type == "pulser":
             utils.logger.info("... keeping only pulser events")
             self.data = self.data[self.data["flag_pulser"]]
+        elif self.evt_type == "FC_bsln":
+            utils.logger.info("... keeping only FC baseline events")
+            self.data = self.data[self.data["flag_FC_bsln"]]
+        elif self.evt_type == "muon":
+            utils.logger.info("... keeping only muon events")
+            self.data = self.data[self.data["flag_muon"]]
         elif self.evt_type == "phy":
             utils.logger.info("... keeping only physical (non-pulser) events")
             self.data = self.data[~self.data["flag_pulser"]]

--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -219,9 +219,9 @@ def generate_plots(config: dict, plt_path: str):
             # -------------------------------------------------------------------------
             # flag pulser events for future parameter data selection
             subsystems[system].flag_pulser_events(subsystems["pulser"])
-            # flag FC baseline events 
+            # flag FC baseline events
             subsystems[system].flag_fcbsln_events(subsystems["FC_bsln"])
-            # flag muon events 
+            # flag muon events
             subsystems[system].flag_muon_events(subsystems["muon"])
 
             # remove timestamps for given detectors (moved here cause otherwise timestamps for flagging don't match)

--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -196,7 +196,6 @@ def generate_plots(config: dict, plt_path: str):
     subsystems["muon"].get_data(parameters)
     utils.logger.debug(subsystems["muon"].data)
 
-
     # -------------------------------------------------------------------------
     # What subsystems do we want to plot?
     subsystems_to_plot = list(config["subsystems"].keys())
@@ -223,7 +222,7 @@ def generate_plots(config: dict, plt_path: str):
             # flag pulser events for future parameter data selection
             subsystems[system].flag_pulser_events(subsystems["pulser"])
             # flag FC baseline events 
-            subsystems[system].flag_FCbsln_events(subsystems["FC_bsln"])
+            subsystems[system].flag_fcbsln_events(subsystems["FC_bsln"])
             # flag muon events 
             subsystems[system].flag_muon_events(subsystems["muon"])
 

--- a/src/legend_data_monitor/core.py
+++ b/src/legend_data_monitor/core.py
@@ -167,6 +167,10 @@ def generate_plots(config: dict, plt_path: str):
         )
         sys.exit()
 
+
+    # -------------------------------------------------------------------------
+    # flag events - PULSER
+    # -------------------------------------------------------------------------
     # put it in a dict, so that later, if pulser is also wanted to be plotted, we don't have to load it twice
     subsystems = {"pulser": subsystem.Subsystem("pulser", dataset=config["dataset"])}
     # get list of all parameters needed for all requested plots, if any
@@ -177,9 +181,26 @@ def generate_plots(config: dict, plt_path: str):
     utils.logger.debug(subsystems["pulser"].data)
 
     # -------------------------------------------------------------------------
+    # flag events - FC baseline
+    # -------------------------------------------------------------------------
+    subsystems["FC_bsln"] = subsystem.Subsystem("FC_bsln", dataset=config["dataset"])
+    parameters = utils.get_all_plot_parameters("FC_bsln", config)
+    subsystems["FC_bsln"].get_data(parameters)
+    utils.logger.debug(subsystems["FC_bsln"].data)
 
+    # -------------------------------------------------------------------------
+    # flag events - muon
+    # -------------------------------------------------------------------------
+    subsystems["muon"] = subsystem.Subsystem("muon", dataset=config["dataset"])
+    parameters = utils.get_all_plot_parameters("muon", config)
+    subsystems["muon"].get_data(parameters)
+    utils.logger.debug(subsystems["muon"].data)
+
+
+    # -------------------------------------------------------------------------
     # What subsystems do we want to plot?
     subsystems_to_plot = list(config["subsystems"].keys())
+
 
     for system in subsystems_to_plot:
         # -------------------------------------------------------------------------
@@ -195,9 +216,18 @@ def generate_plots(config: dict, plt_path: str):
             # get data for these parameters and dataset range
             subsystems[system].get_data(parameters)
             utils.logger.debug(subsystems[system].data)
+
+            # -------------------------------------------------------------------------
+            # flag events
+            # -------------------------------------------------------------------------
             # flag pulser events for future parameter data selection
             subsystems[system].flag_pulser_events(subsystems["pulser"])
-            # remove timestamps for given detectors (moved here cause otherwise pulser timestamps for flagging don't match)
+            # flag FC baseline events 
+            subsystems[system].flag_FCbsln_events(subsystems["FC_bsln"])
+            # flag muon events 
+            subsystems[system].flag_muon_events(subsystems["muon"])
+
+            # remove timestamps for given detectors (moved here cause otherwise timestamps for flagging don't match)
             subsystems[system].remove_timestamps(utils.REMOVE_KEYS)
             utils.logger.debug(subsystems[system].data)
 

--- a/src/legend_data_monitor/plot_styles.py
+++ b/src/legend_data_monitor/plot_styles.py
@@ -233,7 +233,7 @@ def plot_histo(
         if plot_info["unit_label"] == "%"
         else f"{plot_info['label']} [{plot_info['unit_label']}]"
     )
-    fig.supylabel(x_label)
+    fig.supxlabel(x_label)
 
 
 def plot_scatter(

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -157,6 +157,7 @@ def make_subsystem_plots(
                 "pulser": "puls",
                 "pulser_aux": "puls",
                 "FC_bsln": "bsln",
+                "muon": "muon",
             }[subsystem.type],
         }
 
@@ -213,7 +214,7 @@ def make_subsystem_plots(
 
             # threshold values are needed for status map; might be needed for plotting limits on canvas too
             # only needed for single param plots (for now)
-            if subsystem.type not in ["pulser", "pulser_aux", "FC_bsln"]:
+            if subsystem.type not in ["pulser", "pulser_aux", "FC_bsln", "muon"]:
                 keyword = "variation" if plot_settings["variation"] else "absolute"
                 plot_info["limits"] = utils.PLOT_INFO[params[0]]["limits"][
                     subsystem.type
@@ -255,7 +256,7 @@ def make_subsystem_plots(
         # -------------------------------------------------------------------------
 
         if "status" in plot_settings and plot_settings["status"]:
-            if subsystem.type in ["pulser", "pulser_aux", "FC_bsln"]:
+            if subsystem.type in ["pulser", "pulser_aux", "FC_bsln", "muon"]:
                 utils.logger.debug(
                     f"Thresholds are not enabled for {subsystem.type}! Use you own eyes to do checks there"
                 )
@@ -352,8 +353,8 @@ def plot_per_ch(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
                 df_text["name"]
                 + "\n"
                 + f"channel {df_text['channel']}\n"
-                + f"position {df_text['position']}"
             )
+            text += f"position {df_text['position']}" if plot_info["subsystem"] not in ["pulser", "pulser_aux", "FC_bsln", "muon"] else ""
             if len(plot_info["parameters"]) == 1:
                 # in case of 1 parameter, "param mean" entry is a single string param_mean
                 # in case of > 1, it's a list of parameters -> ignore for now and plot mean only for 1 param case
@@ -387,7 +388,7 @@ def plot_per_ch(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
             ax_idx += 1
 
         # -------------------------------------------------------------------------------
-        if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln"]:
+        if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln", "muon"]:
             y_title = 1.05
             axes[0].set_title("")
         else:
@@ -401,7 +402,7 @@ def plot_per_ch(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
 
 
 def plot_per_cc4(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
-    if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln"]:
+    if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln", "muon"]:
         utils.logger.error(
             "\033[91mPlotting per CC4 is not available for %s channel.\nTry again with a different plot structure!\033[0m",
             plot_info["subsystem"],
@@ -480,7 +481,7 @@ def plot_per_cc4(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
 
     # -------------------------------------------------------------------------------
     y_title = (
-        1.05 if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln"] else 1.01
+        1.05 if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln", "muon"] else 1.01
     )
     fig.suptitle(f"{plot_info['subsystem']} - {plot_info['title']}", y=y_title)
     save_pdf(plt, pdf)
@@ -567,7 +568,7 @@ def plot_per_string(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
 
     # -------------------------------------------------------------------------------
     y_title = (
-        1.05 if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln"] else 1.01
+        1.05 if plot_info["subsystem"] in ["pulser", "pulser_aux", "FC_bsln", "muon"] else 1.01
     )
     fig.suptitle(f"{plot_info['subsystem']} - {plot_info['title']}", y=y_title)
 

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -361,11 +361,12 @@ def plot_per_ch(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
                 par_mean = data_channel.iloc[0][
                     plot_info["param_mean"]
                 ]  # single number
-                fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
+                if plot_info['parameter'] != "event_rate":
+                    fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
+                    text += "\nFWHM {fwhm_ch}"
 
                 text += (
                     "\n"
-                    + f"FWHM {fwhm_ch}\n"
                     + (
                         f"mean {round(par_mean,3)} [{plot_info['unit']}]"
                         if par_mean is not None
@@ -462,8 +463,11 @@ def plot_per_cc4(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
 
             labels.append(label)
             if len(plot_info["parameters"]) == 1:
-                fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
-                labels[-1] = label + f" - FWHM: {fwhm_ch}"
+                if plot_info['parameter'] != "event_rate":
+                    fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
+                    labels[-1] = label + f" - FWHM: {fwhm_ch}" 
+                else:
+                    labels[-1] = label
             col_idx += 1
 
         # add grid
@@ -548,8 +552,11 @@ def plot_per_string(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
             plot_style(data_channel, fig, axes[ax_idx], plot_info, COLORS[col_idx])
             labels.append(label)
             if len(plot_info["parameters"]) == 1:
-                fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
-                labels[-1] = labels[-1] + f" - FWHM: {fwhm_ch}"
+                if plot_info['parameter'] != "event_rate":
+                    fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
+                    labels[-1] = label + f" - FWHM: {fwhm_ch}" 
+                else:
+                    labels[-1] = label
             col_idx += 1
 
         # add grid

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -364,7 +364,7 @@ def plot_per_ch(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
                 ]  # single number
                 if plot_info['parameter'] != "event_rate":
                     fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
-                    text += "\nFWHM {fwhm_ch}"
+                    text += f"\nFWHM {fwhm_ch}"
 
                 text += (
                     "\n"

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -362,8 +362,10 @@ def plot_per_ch(data_analysis: DataFrame, plot_info: dict, pdf: PdfPages):
                 par_mean = data_channel.iloc[0][
                     plot_info["param_mean"]
                 ]  # single number
-                if plot_info['parameter'] != "event_rate":
-                    fwhm_ch = get_fwhm_for_fixed_ch(data_channel, plot_info["parameter"])
+                if plot_info["parameter"] != "event_rate":
+                    fwhm_ch = get_fwhm_for_fixed_ch(
+                        data_channel, plot_info["parameter"]
+                    )
                     text += f"\nFWHM {fwhm_ch}"
 
                 text += "\n" + (

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -273,7 +273,7 @@ class Subsystem:
         if self.type == "pulser":
             self.flag_pulser_events()
         if self.type == "FC_bsln":
-            self.flag_FCbsln_events()
+            self.flag_fcbsln_events()
         if self.type == "muon":
             self.flag_muon_events()
 
@@ -314,19 +314,19 @@ class Subsystem:
         self.data = self.data.reset_index()
 
 
-    def flag_FCbsln_events(self, FC_bsln=None):
+    def flag_fcbsln_events(self, fc_bsln=None):
         """Flag FC baseline events. If a FC baseline object was provided, flag FC baseline events in data based on its flag."""
         utils.logger.info("... flagging FC baseline events")
 
         # --- if a FC baseline object was provided, flag FC baseline events in data based on its flag
-        if FC_bsln:
+        if fc_bsln:
             try:
-                FC_bsln_timestamps = FC_bsln.data[FC_bsln.data["flag_FC_bsln"]][
+                fc_bsln_timestamps = fc_bsln.data[fc_bsln.data["flag_fc_bsln"]][
                     "datetime"
                 ]  # .set_index('datetime').index
-                self.data["flag_FC_bsln"] = False
+                self.data["flag_fc_bsln"] = False
                 self.data = self.data.set_index("datetime")
-                self.data.loc[FC_bsln_timestamps, "flag_FC_bsln"] = True
+                self.data.loc[fc_bsln_timestamps, "flag_fc_bsln"] = True
             except KeyError:
                 utils.logger.warning(
                     "\033[93mWarning: cannot flag FC baseline events, timestamps don't match!\n \
@@ -343,10 +343,10 @@ class Subsystem:
             high_thr = 3000
             self.data = self.data.set_index("datetime")
             wf_max_rel = self.data["wf_max"] - self.data["baseline"]
-            FC_bsln_timestamps = self.data[wf_max_rel > high_thr].index
+            fc_bsln_timestamps = self.data[wf_max_rel > high_thr].index
             # flag them
-            self.data["flag_FC_bsln"] = False
-            self.data.loc[FC_bsln_timestamps, "flag_FC_bsln"] = True
+            self.data["flag_fc_bsln"] = False
+            self.data.loc[fc_bsln_timestamps, "flag_fc_bsln"] = True
 
         self.data = self.data.reset_index()
 

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -313,7 +313,6 @@ class Subsystem:
 
         self.data = self.data.reset_index()
 
-
     def flag_fcbsln_events(self, fc_bsln=None):
         """Flag FC baseline events. If a FC baseline object was provided, flag FC baseline events in data based on its flag."""
         utils.logger.info("... flagging FC baseline events")

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -17,7 +17,7 @@ class Subsystem:
     """
     Object containing information for a given subsystem such as channel map, channels status etc.
 
-    sub_type [str]: geds | spms | pulser | pulser_aux | FC_bsln
+    sub_type [str]: geds | spms | pulser | pulser_aux | FC_bsln | muon
 
     Options for kwargs
 
@@ -384,6 +384,18 @@ class Subsystem:
                             entry["system"] == "bsln"
                             and entry["daq"][ch_flag] == 1027200
                         )
+            # special case for muon channel 
+            if self.type == "muon":
+                if self.experiment == "L60":
+                    return entry["system"] == "auxs" and entry["daq"]["fcid"] == 1
+                if self.experiment == "L200":
+                    if self.below_period_3_excluded():
+                        return entry["system"] == "auxs" and entry["daq"][ch_flag] == 2
+                    if self.above_period_3_included():
+                        return (
+                            entry["system"] == "auxs"
+                            and entry["daq"][ch_flag] == 1027202
+                        )
             # for geds or spms
             return entry["system"] == self.type
 
@@ -394,7 +406,7 @@ class Subsystem:
         type_code = {"B": "bege", "C": "coax", "V": "icpc", "P": "ppc"}
 
         # systems for which the location/position has to be handled carefully; values were chosen arbitrarily to avoid conflicts
-        special_systems = {"pulser": 0, "pulser_aux": -1, "FC_bsln": -2}
+        special_systems = {"pulser": 0, "pulser_aux": -1, "FC_bsln": -2, "muon": -3}
 
         # -------------------------------------------------------------------------
         # loop over entries and find out subsystem
@@ -412,17 +424,17 @@ class Subsystem:
             if not is_subsystem(entry_info):
                 continue
 
-            # --- add info for this channel - Raw/FlashCam ID, unique for geds/spms/pulser/pulser_aux/FC_bsln
+            # --- add info for this channel - Raw/FlashCam ID, unique for geds/spms/pulser/pulser_aux/FC_bsln/muon
             ch = entry_info["daq"][ch_flag]
 
             df_map.at[ch, "name"] = entry_info["name"]
-            # number/name of string/fiber for geds/spms, dummy for pulser/pulser_aux/FC_bsln
+            # number/name of string/fiber for geds/spms, dummy for pulser/pulser_aux/FC_bsln/muon
             df_map.at[ch, "location"] = (
                 special_systems[self.type]
                 if self.type in special_systems
                 else entry_info["location"][loc_code[self.type]]
             )
-            # position in string/fiber for geds/spms, dummy for pulser/pulser_aux/FC_bsln
+            # position in string/fiber for geds/spms, dummy for pulser/pulser_aux/FC_bsln/muon
             df_map.at[ch, "position"] = (
                 special_systems[self.type]
                 if self.type in special_systems
@@ -497,7 +509,7 @@ class Subsystem:
             timestamp=self.first_timestamp, system=self.datatype
         )["analysis"]
 
-        # AUX channels are not in status map, so at least for pulser/pulser_aux/FC_bsln need default on
+        # AUX channels are not in status map, so at least for pulser/pulser_aux/FC_bsln/muon need default on
         self.channel_map["status"] = "on"
         self.channel_map = self.channel_map.set_index("name")
         # 'channel_name', for instance, has the format 'DNNXXXS' (= "name" column)

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -272,8 +272,13 @@ class Subsystem:
 
         if self.type == "pulser":
             self.flag_pulser_events()
+        if self.type == "FC_bsln":
+            self.flag_FCbsln_events()
+        if self.type == "muon":
+            self.flag_muon_events()
 
     def flag_pulser_events(self, pulser=None):
+        """Flag pulser events. If a pulser object was provided, flag pulser events in data based on its flag."""
         utils.logger.info("... flagging pulser events")
 
         # --- if a pulser object was provided, flag pulser events in data based on its flag
@@ -305,6 +310,80 @@ class Subsystem:
             # flag them
             self.data["flag_pulser"] = False
             self.data.loc[pulser_timestamps, "flag_pulser"] = True
+
+        self.data = self.data.reset_index()
+
+
+    def flag_FCbsln_events(self, FC_bsln=None):
+        """Flag FC baseline events. If a FC baseline object was provided, flag FC baseline events in data based on its flag."""
+        utils.logger.info("... flagging FC baseline events")
+
+        # --- if a FC baseline object was provided, flag FC baseline events in data based on its flag
+        if FC_bsln:
+            try:
+                FC_bsln_timestamps = FC_bsln.data[FC_bsln.data["flag_FC_bsln"]][
+                    "datetime"
+                ]  # .set_index('datetime').index
+                self.data["flag_FC_bsln"] = False
+                self.data = self.data.set_index("datetime")
+                self.data.loc[FC_bsln_timestamps, "flag_FC_bsln"] = True
+            except KeyError:
+                utils.logger.warning(
+                    "\033[93mWarning: cannot flag FC baseline events, timestamps don't match!\n \
+                    If you are you looking at calibration data, it's not possible to flag FC baseline events in it this way.\n \
+                    Contact the developers if you would like them to focus on advanced flagging methods.\033[0m"
+                )
+                utils.logger.warning(
+                    "\033[93m! Proceeding without FC baseline flag !\033[0m"
+                )
+
+        else:
+            # --- if no object was provided, it's understood that this itself is a FC baseline
+            # find timestamps over threshold
+            high_thr = 3000
+            self.data = self.data.set_index("datetime")
+            wf_max_rel = self.data["wf_max"] - self.data["baseline"]
+            FC_bsln_timestamps = self.data[wf_max_rel > high_thr].index
+            # flag them
+            self.data["flag_FC_bsln"] = False
+            self.data.loc[FC_bsln_timestamps, "flag_FC_bsln"] = True
+
+        self.data = self.data.reset_index()
+
+
+    def flag_muon_events(self, muon=None):
+        """Flag muon events. If a muon object was provided, flag muon events in data based on its flag."""
+        utils.logger.info("... flagging muon events")
+
+        # --- if a muon object was provided, flag muon events in data based on its flag
+        if muon:
+            try:
+                muon_timestamps = muon.data[muon.data["flag_muon"]][
+                    "datetime"
+                ]  # .set_index('datetime').index
+                self.data["flag_muon"] = False
+                self.data = self.data.set_index("datetime")
+                self.data.loc[muon_timestamps, "flag_muon"] = True
+            except KeyError:
+                utils.logger.warning(
+                    "\033[93mWarning: cannot flag muon events, timestamps don't match!\n \
+                    If you are you looking at calibration data, it's not possible to flag muon events in it this way.\n \
+                    Contact the developers if you would like them to focus on advanced flagging methods.\033[0m"
+                )
+                utils.logger.warning(
+                    "\033[93m! Proceeding without muon flag !\033[0m"
+                )
+
+        else:
+            # --- if no object was provided, it's understood that this itself is a muon
+            # find timestamps over threshold
+            high_thr = 500
+            self.data = self.data.set_index("datetime")
+            wf_max_rel = self.data["wf_max"] - self.data["baseline"]
+            muon_timestamps = self.data[wf_max_rel > high_thr].index
+            # flag them
+            self.data["flag_muon"] = False
+            self.data.loc[muon_timestamps, "flag_muon"] = True
 
         self.data = self.data.reset_index()
 
@@ -540,7 +619,7 @@ class Subsystem:
         # --- always read timestamp
         params = ["timestamp"]
         # --- always get wf_max & baseline for pulser for flagging
-        if self.type == "pulser":
+        if self.type in ["pulser", "FC_bsln", "muon"]:
             params += ["wf_max", "baseline"]
 
         # --- add user requested parameters


### PR DESCRIPTION
Playing with wf_max-baseline thresholds in different aux channels, we can also select events in geds/spms/... that are associated with ```FC_bsln``` events in BSLN01 channel. The same can be done with ```muon``` events tagged in MUON01 channel.



If you want to plot geds energy in correspondence of muon events, do:
``` bash
"subsystems": {
    "geds": {
      "Calibrated energy": {
        "parameters": "cuspEmax_ctc_cal",
        "event_type": "muon", // !!!
        "plot_structure": "per string",
        "resampled": "no",
        "plot_style": "histogram",
        "variation": false,
        "time_window": "10T",
        "range": [null, null]
      }
    }
  }
```

If you want to plot geds energy in correspondence of auto-triggered FC baseline events, do:
``` bash
"subsystems": {
    "geds": {
      "Calibrated energy": {
        "parameters": "cuspEmax_ctc_cal",
        "event_type": "FC_bsln", // !!!
        "plot_structure": "per string",
        "resampled": "no",
        "plot_style": "histogram",
        "variation": false,
        "time_window": "10T",
        "range": [null, null]
      }
    }
  }
```