### PR TITLE
new module for retrieving SC params

### DIFF
--- a/docs/source/manuals/get_sc_plots.rst
+++ b/docs/source/manuals/get_sc_plots.rst
@@ -6,7 +6,7 @@ How to load SC data
 
 A number of parameters related to the LEGEND hardware configuration and status are recorded in the Slow Control (SC) database. 
 The latter, PostgreSQL database resides on the ``legend-sc.lngs.infn.it`` host, part of the LNGS network.
-To access the SC databse, follow the `Confluence (Python Software Stack) <https://legend-exp.atlassian.net/wiki/spaces/LEGEND/pages/494764033/Python+Software+Stack>`_ instructions.
+To access the SC database, follow the `Confluence (Python Software Stack) <https://legend-exp.atlassian.net/wiki/spaces/LEGEND/pages/494764033/Python+Software+Stack>`_ instructions.
 Data are loaded following the ``pylegendmeta`` tutorial , which shows how to inspect the database.
 
 

--- a/docs/source/manuals/get_sc_plots.rst
+++ b/docs/source/manuals/get_sc_plots.rst
@@ -21,16 +21,37 @@ Files are collected in the output folder specified in the ``output`` config entr
   "output": "<some_path>/out",
   // ...
 
-Since SC data does not depend on any dataset info (``experiment``, ``period``, ``version``, ``type``) but the selected time interval,
-the output folder is generally structured as it follows:
+In principle, for plotting the SC data you would need just the start and the end of a time interval of interest. This means that SC data does not depend on any dataset info (``experiment``, ``period``, ``version``, ``type``) but ``time_selection``.
+However, there are cases were we want to inspect a given run or time period made of keys as we usually do with germanium.
+
+In the first case, we end up saving data in the following folder:
 
 .. code-block::
 
   <some_path>/out/
-    └── <time_selection>
-      ├── SC-<time_selection>.pdf
-      ├── SC-<time_selection>.log
-      └── SC-<time_selection>.{dat,bak,dir}
+    └── generated
+      └── plt
+        └── SC
+          └── <time_selection>
+            ├── SC-<time_selection>.pdf
+            ├── SC-<time_selection>.log
+            └── SC-<time_selection>.{dat,bak,dir}
+
+Otherwise, we store the SC data/plots as usual:
+
+.. code-block::
+
+  <some_path>/out/
+    └── generated
+      └── plt
+        └── <type>
+          └── <period>
+            └── SC
+              └── <time_selection>
+                ├── SC-<time_selection>.pdf
+                ├── SC-<time_selection>.log
+                └── SC-<time_selection>.{dat,bak,dir}
+
 
 .. note::
 

--- a/docs/source/manuals/get_sc_plots.rst
+++ b/docs/source/manuals/get_sc_plots.rst
@@ -1,0 +1,59 @@
+How to load and plot Slow Control data
+======================================
+
+How to load SC data
+-------------------
+
+A number of parameters related to the LEGEND hardware configuration and status are recorded in the Slow Control (SC) database. 
+The latter, PostgreSQL database resides on the ``legend-sc.lngs.infn.it`` host, part of the LNGS network.
+To access the SC databse, follow the `Confluence (Python Software Stack) <https://legend-exp.atlassian.net/wiki/spaces/LEGEND/pages/494764033/Python+Software+Stack>`_ instructions.
+Data are loaded following the ``pylegendmeta`` tutorial , which shows how to inspect the database.
+
+
+... put here some text on how to specify the plotting of a SC parameter in the config file (no ideas for the moment)...
+
+
+Files are collected in the output folder specified in the ``output`` config entry:
+
+.. code-block:: json
+
+  {
+  "output": "<some_path>/out",
+  // ...
+
+Since SC data does not depend on any dataset info (``experiment``, ``period``, ``version``, ``type``) but the selected time interval,
+the output folder is generally structured as it follows:
+
+.. code-block::
+
+  <some_path>/out/
+    └── <time_selection>
+      ├── SC-<time_selection>.pdf
+      ├── SC-<time_selection>.log
+      └── SC-<time_selection>.{dat,bak,dir}
+
+.. note::
+
+  ``time_selection`` can assume one of the following formats, depending on what we put as a time range into ``dataset``:
+
+  - if ``{'start': '20220928T080000Z', 'end': '20220928T093000Z'}`` (start + end), then <time_selection> = ``20220928T080000Z_20220928T093000Z``;
+  - if ``{'timestamps': ['20230207T103123Z']}`` (one key), then <time_selection> = ``20230207T103123Z``;
+  - if ``{'timestamps': ['20230207T103123Z', '20230207T141123Z', '20230207T083323Z']}`` (multiple keys), then <time_selection> = ``20230207T083323Z_20230207T141123Z`` (min/max timestamp interval)
+  - if ``{'runs': 1}`` (one run), then <time_selection> = ``r001``;
+  - if ``{'runs': [1, 2, 3]}`` (multiple runs), then <time_selection> = ``r001_r002_r003``.
+
+Shelve output objects
+~~~~~~~~~~~~~~~~~~~~~
+*Under construction...*
+
+
+Available SC parameters
+-----------------------
+
+Available parameters include:
+
+- ``PT114``, ``PT115``, ``PT118`` (cryostat pressures)
+- ``PT202``, ``PT205``, ``PT208`` (cryostat vacuum)
+- ``LT01`` (water loop fine fill level)
+- ``RREiT`` (injected air temperature clean room), ``RRNTe`` (clean room temperature north), ``RRSTe`` (clean room temperature south), ``ZUL_T_RR`` (supply air temperature clean room)
+- ``DaqLeft-Temp1``, ``DaqLeft-Temp2``, ``DaqRight-Temp1``, ``DaqRight-Temp2`` (rack present temperatures)

--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -1,0 +1,131 @@
+import matplotlib.pyplot as plt
+import sys
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from datetime import datetime, timezone
+from matplotlib.backends.backend_pdf import PdfPages
+from pandas import DataFrame, Timedelta, concat
+
+from legendmeta import LegendSlowControlDB
+scdb = LegendSlowControlDB()
+scdb.connect(password="...")  # ????????????????????
+
+from . import utils
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# SLOW CONTROL LOADING/PLOTTING FUNCTIONS
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Necessary to perform the SSH tunnel to the databse
+def get_sc_df(param="PT118"):
+    """
+    def ssh_tunnel():
+        import subprocess
+        #ssh_tunnel_cmd = 'ssh -t ugnet-proxy' 
+        #full_ssh_cmd = ssh_tunnel_cmd
+        #subprocess.run(full_ssh_cmd, shell=True)
+        #subprocess.Popen(["ssh", "-t", "ugnet-proxy"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    """
+
+    # load info from settings/SC-params.json
+    sc_params = utils.SC_PARAMETERS
+
+    # check if parameter is within the one listed in settings/SC-params.json
+    if param not in sc_params['SC_DB_params'].keys():
+        utils.logger.error(f"\033[91mThe parameter {param} is not present in 'settings/SC-params.json'. Try again with another parameter or update the json file!\033[0m")
+        sys.exit()
+
+    # get data
+    df_param = load_table_and_apply_flags(param, sc_params)
+    unit, lower_lim, upper_lim = get_plotting_info(param, sc_params)
+
+
+    exit()
+
+
+def load_table_and_apply_flags(param: str, sc_params: dict) -> DataFrame:
+    """Load the corresponding table from SC database for the process of interest and apply already the flags for the parameter under study."""
+    # getting the process and flags of interest from 'settings/SC-params.json' for the provided parameter
+    table_param = sc_params['SC_DB_params'][param]['table']
+    flags_param = sc_params['SC_DB_params'][param]['flags']
+
+    # check if the selected table is present in the SC database. If not, arise an error and exit
+    if table_param not in scdb.get_tables():
+        utils.logger.error("\033[91mThis is not present in the SC database! Try again.\033[0m")
+        sys.exit()
+    
+    # Assuming T1 and T2 are datetime objects or strings in the format 'YYYY-MM-DD HH:MM:SS' (we'll apply a time query to shorten the df loading time)
+    T1 = '2023-01-09 00:00:00'
+    T2 = '2023-01-09 06:00:00'
+
+    # get the dataframe for the process of interest
+    utils.logger.debug(f"... getting the dataframe for '{table_param}' in the time range of interest")
+    # SQL query to filter the dataframe based on the time range
+    query = f"SELECT * FROM {table_param} WHERE tstamp >= '{T1}' AND tstamp <= '{T2}'"
+    get_table_df = scdb.dataframe(query)
+    # order by timestamp (not automatically done)
+    get_table_df = get_table_df.sort_values(by="tstamp")
+
+    utils.logger.debug(get_table_df)
+
+    # let's apply the flags for keeping only the parameter of interest
+    utils.logger.debug(f"... applying flags to get the parameter '{param}'")
+    get_table_df = apply_flags(get_table_df, sc_params, flags_param)
+    utils.logger.debug("... after flagging the events:", get_table_df)
+
+    return get_table_df
+
+
+
+def get_plotting_info(param: str, sc_params: dict): # -> str, float, float:
+    """Return units and low/high limits of a given parameter."""
+    table_param = sc_params['SC_DB_params'][param]['table']
+    flags_param = sc_params['SC_DB_params'][param]['flags']
+    
+    # get info dataframe of the corresponding process under study (do I need to specify the param????)
+    get_table_info = scdb.dataframe(table_param.replace("snap", "info"))
+
+    # let's apply the flags for keeping only the parameter of interest
+    get_table_info = apply_flags(get_table_info, sc_params, flags_param)
+    utils.logger.debug("... units and thresholds will be retrieved from the following object: %s", get_table_info)
+
+    # To get units and limits, consider they might change over time
+    # This means we have to query the dataframe get the correct values based on the inspected time interval
+    T1 = '2023-04-01 00:00:00'
+    T2 = '2023-04-01 15:00:00'
+
+    # Convert T1 and T2 to datetime objects in the UTC timezone
+    T1 = datetime.strptime(T1, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+    T2 = datetime.strptime(T2, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+
+    # Filter the DataFrame based on the time interval, starting to look from the latest entry ('reversed(...)')
+    times = list(get_table_info['tstamp'].unique()) 
+    for time in reversed(times):
+        if T1 < time < T2:
+            unit = list(get_table_info['unit'].unique())[0] 
+            lower_lim = upper_lim = None
+            utils.logger.warning(f"\033[93mParameter {param} has no valid range in the time period you selected. Upper and lower thresholds are set to None, while units={unit}\033[0m")
+            return unit, lower_lim, upper_lim
+
+        if time < T1 and time < T2:
+            unit = list(get_table_info[get_table_info['tstamp'] == time]['unit'].unique())[0] 
+            lower_lim = get_table_info[get_table_info['tstamp'] == time]['ltol'].tolist()[-1]
+            upper_lim = get_table_info[get_table_info['tstamp'] == time]['utol'].tolist()[-1]
+            utils.logger.debug(f"... parameter {param} must be within [{lower_lim};{upper_lim}] {unit}")
+            return unit, lower_lim, upper_lim
+
+        if time > T1 and time > T2:
+            utils.logger.error("\033[91mYou're travelling too far in the past, there were no SC data in the time period you selected. Try again!\033[0m")
+            sys.exit()
+
+    return unit, lower_lim, upper_lim
+
+
+def apply_flags(df: DataFrame, sc_params: dict, flags_param: list) -> DataFrame:
+    """Apply the flags read from 'settings/SC-params.json' to the input dataframe."""
+    for flag in flags_param:
+        column = sc_params['expressions'][flag]['column']
+        entry = sc_params['expressions'][flag]['entry']
+        df = df[df[column] == entry]
+
+    return df

--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -23,14 +23,14 @@ dataset = {
     "type": "phy",
     #"runs": 0
     #"runs": [0,1]
-    "start": "2023-04-08 10:00:00",
-    "end": "2023-04-08 11:00:00"
+    "start": "2023-04-06 10:00:00",
+    "end": "2023-04-08 13:00:00"
 }
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # SLOW CONTROL LOADING/PLOTTING FUNCTIONS
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-def get_sc_df(param="PT118", dataset=dataset): 
+def get_sc_df(param="DaqLeft-Temp2", dataset=dataset): 
     """
     # Necessary to perform the SSH tunnel to the databse
     def ssh_tunnel():
@@ -107,6 +107,7 @@ def get_plotting_info(param: str, sc_params: dict, first_tstmp: str, last_tstmp:
 
     # Filter the DataFrame based on the time interval, starting to look from the latest entry ('reversed(...)')
     times = list(get_table_info['tstamp'].unique()) 
+
     for time in reversed(times):
         if first_tstmp < time < last_tstmp:
             unit = list(get_table_info['unit'].unique())[0] 
@@ -122,8 +123,9 @@ def get_plotting_info(param: str, sc_params: dict, first_tstmp: str, last_tstmp:
             return unit, lower_lim, upper_lim
 
         if time > first_tstmp and time > last_tstmp:
-            utils.logger.error("\033[91mYou're travelling too far in the past, there were no SC data in the time period you selected. Try again!\033[0m")
-            sys.exit()
+            if time == times[0]:
+                utils.logger.error("\033[91mYou're travelling too far in the past, there were no SC data in the time period you selected. Try again!\033[0m")
+                sys.exit()
 
     return unit, lower_lim, upper_lim
 
@@ -134,5 +136,10 @@ def apply_flags(df: DataFrame, sc_params: dict, flags_param: list) -> DataFrame:
         column = sc_params['expressions'][flag]['column']
         entry = sc_params['expressions'][flag]['entry']
         df = df[df[column] == entry]
+
+    # check if the dataframe is empty
+    if df.empty:
+        utils.logger.error("\033[91mThe dataframe is empty. Exiting now!\033[0m")
+        exit()
 
     return df

--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -1,9 +1,9 @@
 import sys
 from datetime import datetime, timezone
 from typing import Tuple
-from pandas import DataFrame
 
 from legendmeta import LegendSlowControlDB
+from pandas import DataFrame
 
 from . import utils
 

--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -1,6 +1,7 @@
 import sys
 from datetime import datetime, timezone
 from typing import Tuple
+from pandas import DataFrame
 
 from legendmeta import LegendSlowControlDB
 from . import utils
@@ -20,17 +21,6 @@ dataset = {
     "start": "2023-04-06 10:00:00",
     "end": "2023-04-08 13:00:00",
 }
-
-"""
-# Necessary to perform the SSH tunnel to the database
-def ssh_tunnel():
-    import subprocess
-    #ssh_tunnel_cmd = 'ssh -t ugnet-proxy'
-    #full_ssh_cmd = ssh_tunnel_cmd
-    #subprocess.run(full_ssh_cmd, shell=True)
-    #subprocess.Popen(["ssh", "-t", "ugnet-proxy"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-"""
-
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # SLOW CONTROL LOADING/PLOTTING FUNCTIONS

--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -3,6 +3,7 @@ import sys
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from typing import Tuple
 from datetime import datetime, timezone
 from matplotlib.backends.backend_pdf import PdfPages
 from pandas import DataFrame, Timedelta, concat
@@ -13,12 +14,25 @@ scdb.connect(password="...")  # ????????????????????
 
 from . import utils
 
+# instead of dataset, retrieve 'config["dataset"]' from config json
+dataset = {
+    "experiment": "L200",
+    "period": "p03",
+    "version": "",
+    "path": "/data2/public/prodenv/prod-blind/tmp/auto",
+    "type": "phy",
+    #"runs": 0
+    #"runs": [0,1]
+    "start": "2023-04-08 10:00:00",
+    "end": "2023-04-08 11:00:00"
+}
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # SLOW CONTROL LOADING/PLOTTING FUNCTIONS
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Necessary to perform the SSH tunnel to the databse
-def get_sc_df(param="PT118"):
+def get_sc_df(param="PT118", dataset=dataset): 
     """
+    # Necessary to perform the SSH tunnel to the databse
     def ssh_tunnel():
         import subprocess
         #ssh_tunnel_cmd = 'ssh -t ugnet-proxy' 
@@ -35,15 +49,17 @@ def get_sc_df(param="PT118"):
         utils.logger.error(f"\033[91mThe parameter {param} is not present in 'settings/SC-params.json'. Try again with another parameter or update the json file!\033[0m")
         sys.exit()
 
-    # get data
-    df_param = load_table_and_apply_flags(param, sc_params)
-    unit, lower_lim, upper_lim = get_plotting_info(param, sc_params)
+    # get first/last timestamps to use when querying data from the SC database
+    timerange, first_tstmp, last_tstmp = utils.get_query_times(dataset=dataset)
 
-
+    # get data from the SC database
+    df_param = load_table_and_apply_flags(param, sc_params, first_tstmp, last_tstmp)
+    # get units and lower/upper limits for the parameter of interest
+    unit, lower_lim, upper_lim = get_plotting_info(param, sc_params, first_tstmp, last_tstmp)
     exit()
 
 
-def load_table_and_apply_flags(param: str, sc_params: dict) -> DataFrame:
+def load_table_and_apply_flags(param: str, sc_params: dict, first_tstmp: str, last_tstmp: str) -> DataFrame:
     """Load the corresponding table from SC database for the process of interest and apply already the flags for the parameter under study."""
     # getting the process and flags of interest from 'settings/SC-params.json' for the provided parameter
     table_param = sc_params['SC_DB_params'][param]['table']
@@ -54,14 +70,10 @@ def load_table_and_apply_flags(param: str, sc_params: dict) -> DataFrame:
         utils.logger.error("\033[91mThis is not present in the SC database! Try again.\033[0m")
         sys.exit()
     
-    # Assuming T1 and T2 are datetime objects or strings in the format 'YYYY-MM-DD HH:MM:SS' (we'll apply a time query to shorten the df loading time)
-    T1 = '2023-01-09 00:00:00'
-    T2 = '2023-01-09 06:00:00'
-
     # get the dataframe for the process of interest
-    utils.logger.debug(f"... getting the dataframe for '{table_param}' in the time range of interest")
+    utils.logger.debug(f"... getting the dataframe for '{table_param}' in the time range of interest\n")
     # SQL query to filter the dataframe based on the time range
-    query = f"SELECT * FROM {table_param} WHERE tstamp >= '{T1}' AND tstamp <= '{T2}'"
+    query = f"SELECT * FROM {table_param} WHERE tstamp >= '{first_tstmp}' AND tstamp <= '{last_tstmp}'"
     get_table_df = scdb.dataframe(query)
     # order by timestamp (not automatically done)
     get_table_df = get_table_df.sort_values(by="tstamp")
@@ -71,13 +83,13 @@ def load_table_and_apply_flags(param: str, sc_params: dict) -> DataFrame:
     # let's apply the flags for keeping only the parameter of interest
     utils.logger.debug(f"... applying flags to get the parameter '{param}'")
     get_table_df = apply_flags(get_table_df, sc_params, flags_param)
-    utils.logger.debug("... after flagging the events:", get_table_df)
+    utils.logger.debug("... after flagging the events:\n%s", get_table_df)
 
     return get_table_df
 
 
 
-def get_plotting_info(param: str, sc_params: dict): # -> str, float, float:
+def get_plotting_info(param: str, sc_params: dict, first_tstmp: str, last_tstmp: str) -> Tuple[str, float, float]:
     """Return units and low/high limits of a given parameter."""
     table_param = sc_params['SC_DB_params'][param]['table']
     flags_param = sc_params['SC_DB_params'][param]['flags']
@@ -87,34 +99,29 @@ def get_plotting_info(param: str, sc_params: dict): # -> str, float, float:
 
     # let's apply the flags for keeping only the parameter of interest
     get_table_info = apply_flags(get_table_info, sc_params, flags_param)
-    utils.logger.debug("... units and thresholds will be retrieved from the following object: %s", get_table_info)
+    utils.logger.debug("... units and thresholds will be retrieved from the following object:\n%s", get_table_info)
 
-    # To get units and limits, consider they might change over time
-    # This means we have to query the dataframe get the correct values based on the inspected time interval
-    T1 = '2023-04-01 00:00:00'
-    T2 = '2023-04-01 15:00:00'
-
-    # Convert T1 and T2 to datetime objects in the UTC timezone
-    T1 = datetime.strptime(T1, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
-    T2 = datetime.strptime(T2, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+    # Convert first_tstmp and last_tstmp to datetime objects in the UTC timezone
+    first_tstmp = datetime.strptime(first_tstmp, '%Y%m%dT%H%M%SZ').replace(tzinfo=timezone.utc)
+    last_tstmp = datetime.strptime(last_tstmp, '%Y%m%dT%H%M%SZ').replace(tzinfo=timezone.utc)
 
     # Filter the DataFrame based on the time interval, starting to look from the latest entry ('reversed(...)')
     times = list(get_table_info['tstamp'].unique()) 
     for time in reversed(times):
-        if T1 < time < T2:
+        if first_tstmp < time < last_tstmp:
             unit = list(get_table_info['unit'].unique())[0] 
             lower_lim = upper_lim = None
             utils.logger.warning(f"\033[93mParameter {param} has no valid range in the time period you selected. Upper and lower thresholds are set to None, while units={unit}\033[0m")
             return unit, lower_lim, upper_lim
 
-        if time < T1 and time < T2:
+        if time < first_tstmp and time < last_tstmp:
             unit = list(get_table_info[get_table_info['tstamp'] == time]['unit'].unique())[0] 
             lower_lim = get_table_info[get_table_info['tstamp'] == time]['ltol'].tolist()[-1]
             upper_lim = get_table_info[get_table_info['tstamp'] == time]['utol'].tolist()[-1]
             utils.logger.debug(f"... parameter {param} must be within [{lower_lim};{upper_lim}] {unit}")
             return unit, lower_lim, upper_lim
 
-        if time > T1 and time > T2:
+        if time > first_tstmp and time > last_tstmp:
             utils.logger.error("\033[91mYou're travelling too far in the past, there were no SC data in the time period you selected. Try again!\033[0m")
             sys.exit()
 

--- a/src/legend_data_monitor/run.py
+++ b/src/legend_data_monitor/run.py
@@ -17,6 +17,7 @@ def main():
       $ legend-data-monitor --help # help section
 
     Example JSON configuration file:
+    
     .. code-block:: json
         {
             "dataset": {

--- a/src/legend_data_monitor/settings/SC-params.json
+++ b/src/legend_data_monitor/settings/SC-params.json
@@ -1,9 +1,5 @@
 {
   "SC_DB_params": {
-      "PT118": {
-        "table": "cryostat_snap",
-        "flags": ["is_Pressure", "is_PT118"]
-      },
       "PT114": {
         "table": "cryostat_snap",
         "flags": ["is_Pressure", "is_PT114"]
@@ -11,6 +7,10 @@
       "PT115": {
         "table": "cryostat_snap",
         "flags": ["is_Pressure", "is_PT115"]
+      },
+      "PT118": {
+        "table": "cryostat_snap",
+        "flags": ["is_Pressure", "is_PT118"]
       },
       "PT202": {
         "table": "cryostat_snap",

--- a/src/legend_data_monitor/settings/SC-params.json
+++ b/src/legend_data_monitor/settings/SC-params.json
@@ -1,0 +1,146 @@
+{
+  "SC_DB_params": {
+      "PT118": {
+        "table": "cryostat_snap",
+        "flags": ["is_Pressure", "is_PT118"]
+      },
+      "PT114": {
+        "table": "cryostat_snap",
+        "flags": ["is_Pressure", "is_PT114"]
+      },
+      "PT115": {
+        "table": "cryostat_snap",
+        "flags": ["is_Pressure", "is_PT115"]
+      },
+      "PT202": {
+        "table": "cryostat_snap",
+        "flags": ["is_Vacuum", "is_PT202"]
+      },
+      "PT205": {
+        "table": "cryostat_snap",
+        "flags": ["is_Vacuum", "is_PT205"]
+      },
+      "PT208": {
+        "table": "cryostat_snap",
+        "flags": ["is_Vacuum", "is_PT208"]
+      },
+      "LT01": {
+        "table": "waterloop_snap",
+        "flags": ["is_WaterLoop", "is_LT01"]
+      },
+      "RREiT": {
+        "table": "cleanroom_snap",
+        "flags": ["is_clean", "is_RREiT"]
+      },
+      "RRNTe": {
+        "table": "cleanroom_snap",
+        "flags": ["is_clean", "is_RRNTe"]
+      },
+      "RRSTe": {
+        "table": "cleanroom_snap",
+        "flags": ["is_clean", "is_RRSTe"]
+      },
+      "ZUL_T_RR": {
+        "table": "cleanroom_snap",
+        "flags": ["is_clean", "is_ZUL_T_RR"]
+      },
+      "DaqLeft-Temp1": {
+        "table": "rack_snap",
+        "flags": ["is_temperature", "is_DaqLeft", "is_Temp_1"]
+      },
+      "DaqRight-Temp1": {
+        "table": "rack_snap",
+        "flags": ["is_temperature", "is_DaqRight", "is_Temp_1"]
+      },
+      "DaqLeft-Temp2": {
+        "table": "rack_snap",
+        "flags": ["is_temperature", "is_DaqLeft", "is_Temp_2"]
+      },
+      "DaqRight-Temp2": {
+        "table": "rack_snap",
+        "flags": ["is_temperature", "is_DaqRight", "is_Temp_2"]
+      }
+  },
+  "expressions":{
+    "is_Pressure": {
+        "column": "group", 
+        "entry": "Pressure" 
+    },
+    "is_Vacuum": {
+        "column": "group", 
+        "entry": "Vacuum" 
+    },
+    "is_WaterLoop": {
+        "column": "group", 
+        "entry": "WaterLoop" 
+    },
+    "is_clean": {
+        "column": "group", 
+        "entry": "clean" 
+    },
+    "is_PT114": {
+        "column": "name",
+        "entry": "PT114"
+    },
+    "is_PT115": {
+        "column": "name",
+        "entry": "PT115"
+    },
+    "is_PT118": {
+        "column": "name",
+        "entry": "PT118"
+    },
+    "is_PT202": {
+        "column": "name",
+        "entry": "PT202"
+    },
+    "is_PT205": {
+        "column": "name",
+        "entry": "PT205"
+    },
+    "is_PT208": {
+        "column": "name",
+        "entry": "PT208"
+    },
+    "is_LT01": {
+        "column": "name",
+        "entry": "LT01"
+    },
+    "is_RREiT": {
+        "column": "name",
+        "entry": "RREiT"
+    },
+    "is_RRNTe": {
+        "column": "name",
+        "entry": "RRNTe"
+    },
+    "is_RRSTe": {
+        "column": "name",
+        "entry": "RRSTe"
+    },
+    "is_ZUL_T_RR": {
+        "column": "name",
+        "entry": "ZUL_T_RR"
+    },
+    "is_temperature": {
+        "column": "name",
+        "entry": "Temp"
+    },
+    "is_DaqLeft": {
+        "column": "rack",
+        "entry": "CleanRoom-DaqLeft"
+    },
+    "is_DaqRight": {
+        "column": "rack",
+        "entry": "CleanRoom-DaqRight"
+    },
+    "is_Temp_1": {
+        "column": "sensor",
+        "entry": "Temp-1"
+    },
+    "is_Temp_2": {
+        "column": "sensor",
+        "entry": "Temp-2"
+    }
+  }
+}

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -135,7 +135,7 @@ class Subsystem:
         self.path = data_info["path"]
         self.version = data_info["version"]
 
-        self.timerange, self.first_timestamp = utils.get_query_times(**kwargs)
+        self.timerange, self.first_timestamp, self.last_timestamp = utils.get_query_times(**kwargs)
 
         # None will be returned if something went wrong
         if not self.timerange:

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -49,6 +49,10 @@ for param in SPECIAL_PARAMETERS:
     if isinstance(SPECIAL_PARAMETERS[param], str):
         SPECIAL_PARAMETERS[param] = [SPECIAL_PARAMETERS[param]]
 
+# load SC params and corresponding flags to get specific parameters from big dfs that are stored in the database
+with open(pkg / "settings" / "SC-params.json") as f:
+    SC_PARAMETERS = json.load(f)
+
 # load list of columns to load for a dataframe
 COLUMNS_TO_LOAD = [
     "name",

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -177,8 +177,6 @@ def get_query_times(**kwargs):
         first_timestamp = get_key(first_file)
         last_timestamp = get_last_timestamp(last_file) # ma non e' l'ultimo timestamp, per quello bisogna aprire il file e prendere l'ultima entry!!!
 
-        print("last_run:", last_run, "\tlast_glob_path:", last_glob_path, "\tlast_file:", last_file)
-
     return timerange, first_timestamp, last_timestamp
 
 


### PR DESCRIPTION
First step for including the Slow Control (SC) monitoring in the package. The module ```plot_sc.py``` has a function ```def get_sc_param(param="DaqLeft-Temp2", dataset=dataset)``` that helps getting the parameter (```param```) of interest within a time interval specified in ```dataset``` (see the corresponding docstring for more details). The function returns the dataframe with data (column=```value```) for the specified parameter, containing also a column for the unit (```unit```) and the lower/upper limits (```lower_lim```, ```upper_lim```) if present, otherwise they're set to ```None```.

Right now, the implemented parameters that one can plot from the SC database, are:
- ``PT114``, ``PT115``, ``PT118`` (cryostat pressures)
- ``PT202``, ``PT205``, ``PT208`` (cryostat vacuum)
- ``LT01`` (water loop fine fill level)
- ``RREiT`` (injected air temperature clean room), ``RRNTe`` (clean room temperature north), ``RRSTe`` (clean room temperature south), ``ZUL_T_RR`` (supply air temperature clean room)
- ``DaqLeft-Temp1``, ``DaqLeft-Temp2``, ``DaqRight-Temp1``, ``DaqRight-Temp2`` (rack present temperatures)

The loading and flagging of these parameters is performed thanks to an external json file (see ```settings/sc-params.json```).