### PR TITLE
Added diode vmon/imon from SC db

### DIFF
--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -236,7 +236,7 @@ def include_more_diode_info(df: DataFrame) -> DataFrame:
     if " V00050B" in list(df_info['label'].unique()):
         df_info = df_info[df_info['label'] != ' V00050B']
 
-    # remve 'HV filter test' and 'no cable' entries
+    # remove 'HV filter test' and 'no cable' entries
     df_info = df_info[~df_info['label'].str.contains('Ch')]
     # remove other stuff (???)
     if "?" in list(df_info['label'].unique()):

--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -236,7 +236,7 @@ def include_more_diode_info(df: DataFrame) -> DataFrame:
         df_info = df_info[df_info["label"] != " V00050B"]
 
     # remove 'HV filter test' and 'no cable' entries
-    df_info = df_info[~df_info['label'].str.contains('Ch')]
+    df_info = df_info[~df_info["label"].str.contains("Ch")]
     # remove other stuff (???)
     if "?" in list(df_info["label"].unique()):
         df_info = df_info[df_info["label"] != "?"]

--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -29,7 +29,7 @@ dataset = {
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-def get_sc_param(param="diode_imon", dataset=dataset) -> DataFrame:
+def get_sc_param(param="diode_vmon", dataset=dataset) -> DataFrame:
     """Get data from the Slow Control (SC) database for the specified parameter ```param```.
 
     The ```dataset```  entry is of the following type:
@@ -124,7 +124,14 @@ def load_table_and_apply_flags(
             param, sc_params, first_tstmp, last_tstmp
         )
     else:
-        unit = lower_lim = upper_lim = None # I don't know where to get these info for geds ...
+        lower_lim = upper_lim = None # there are just 'set values', no actual thresholds
+        if "vmon" in param:
+            unit = "V"
+        elif "imon" in param:
+            unit = "\u03BCA"
+        else:
+            unit = None
+
 
     # append unit, lower_lim, upper_lim to the dataframe
     get_table_df["unit"] = unit

--- a/src/legend_data_monitor/settings/SC-params.json
+++ b/src/legend_data_monitor/settings/SC-params.json
@@ -1,5 +1,13 @@
 {
   "SC_DB_params": {
+    "diode_vmon": {
+      "table": "diode_snap",
+      "flags": []
+    },
+    "diode_imon": {
+      "table": "diode_snap",
+      "flags": []
+    },
     "PT114": {
       "table": "cryostat_snap",
       "flags": ["is_Pressure", "is_PT114"]

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -29,10 +29,10 @@ class Subsystem:
             - 'version' [str]: version of pygama data processing format vXX.XX
             - 'type' [str]: 'phy' or 'cal'
             - the following key(s) depending in time selection
-                1) 'start' : <start datetime>, 'end': <end datetime> where <datetime> input is of format 'YYYY-MM-DD hh:mm:ss'
-                2) 'window'[str]: time window in the past from current time point, format: 'Xd Xh Xm' for days, hours, minutes
-                2) 'timestamps': str or list of str in format 'YYYYMMDDThhmmssZ'
-                3) 'runs': int or list of ints for run number(s)  e.g. 10 for r010
+                1. 'start' : <start datetime>, 'end': <end datetime> where <datetime> input is of format 'YYYY-MM-DD hh:mm:ss'
+                2. 'window'[str]: time window in the past from current time point, format: 'Xd Xh Xm' for days, hours, minutes
+                2. 'timestamps': str or list of str in format 'YYYYMMDDThhmmssZ'
+                3. 'runs': int or list of ints for run number(s)  e.g. 10 for r010
     Or input kwargs separately experiment=, period=, path=, version=, type=; start=&end=, or window=, or timestamps=, or runs=
 
     Experiment is needed to know which channel belongs to the pulser Subsystem (and its name), "auxs" ch0 (L60) or "puls" ch1 (L200)


### PR DESCRIPTION
The voltages (```diode_vmon```) or the currents (```diode_imon```) can now be retried from the Slow Control (SC) database.

The dataframe is built such that it already contains some channel info, like 'crate', 'slot', 'channel' (not the one of .lh5 files!), 'name', 'string'.