### PR TITLE
added saving of dataframes for par1 vs par2 case

### DIFF
--- a/src/legend_data_monitor/plot_sc.py
+++ b/src/legend_data_monitor/plot_sc.py
@@ -8,7 +8,7 @@ from pandas import DataFrame
 from . import utils
 
 scdb = LegendSlowControlDB()
-scdb.connect(password="legend00")  # look on Confluence (or ask Sofia) for the password
+scdb.connect(password="...")  # look on Confluence (or ask Sofia) for the password
 
 # instead of dataset, retrieve 'config["dataset"]' from config json
 dataset = {

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -244,17 +244,16 @@ def make_subsystem_plots(
         # -------------------------------------------------------------------------
         # saving dataframe + plot info
         # -------------------------------------------------------------------------
-
-        par_dict_content = {}
-
-        # saving dataframe data for each parameter
-        par_dict_content["df_" + plot_info["subsystem"]] = data_analysis.data
-        par_dict_content["plot_info"] = plot_info
+        # here we are not checking if we are plotting one or more than one parameter
+        # the output dataframe and plot_info objects are merged for more than one parameters
+        # this will be fixed at a later stage, when building the output dictionary through utils.build_out_dict(...)
+        par_dict_content = utils.save_df_and_info(data_analysis.data, plot_info)
 
         # -------------------------------------------------------------------------
         # call status plot
         # -------------------------------------------------------------------------
 
+        # ??? how to deal with more than one parameters? still not implemented
         if "status" in plot_settings and plot_settings["status"]:
             if subsystem.type in ["pulser", "pulser_aux", "FC_bsln", "muon"]:
                 utils.logger.debug(
@@ -272,7 +271,7 @@ def make_subsystem_plots(
         # building a dictionary with dataframe/plot_info to be later stored in a shelve object
         if saving is not None:
             out_dict = utils.build_out_dict(
-                plot_settings, plot_info, par_dict_content, out_dict, saving, plt_path
+                plot_settings, par_dict_content, out_dict
             )
 
     # save in shelve object, overwriting the already existing file with new content (either completely new or new bunches)

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -814,7 +814,7 @@ def build_out_dict(
 
 def save_dict(
     plot_settings: list, plot_info: list, par_dict_content: dict, out_dict: dict
-):
+) -> dict:
     """Create a dictionary with the correct format for being saved in the final shelve object."""
     # get the parameters under study (can be one, can be more for 'par vs par' plot style)
     params = plot_info["parameters"]
@@ -870,14 +870,13 @@ def save_dict(
             "std",
         ]
         new_keys = ["unit", "label", "unit_label", "parameters", "param_mean"]
+        # we have to polish our dataframe and plot_info dictionary from other parameters...
+        # --- original objects
+        plot_info_all = par_dict_content["plot_info"]
+        df_all = par_dict_content["df_" + plot_info_all["subsystem"]]
 
         for param in params:
             parameter = param.split("_var")[0] if "_var" in param else param
-
-            # we have to polish our dataframe and plot_info dictionary from other parameters...
-            # --- original objects
-            plot_info_all = par_dict_content["plot_info"]
-            df_all = par_dict_content["df_" + plot_info_all["subsystem"]]
 
             #  --- cleaned plot_info
             plot_info_param = {key: plot_info_all[key] for key in keep_keys}

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -720,7 +720,7 @@ def add_config_entries(
 # -------------------------------------------------------------------------
 
 def save_df_and_info(df: DataFrame, plot_info: dict) -> dict:
-    """Returns a dictionary containing a dataframe for the parameter(s) under study for a given subsystem. The plotting info are saved too."""
+    """Return a dictionary containing a dataframe for the parameter(s) under study for a given subsystem. The plotting info are saved too."""
     par_dict_content = {
         "df_" + plot_info["subsystem"]: df, # saving dataframe
         "plot_info": plot_info # saving plotting info

--- a/src/legend_data_monitor/utils.py
+++ b/src/legend_data_monitor/utils.py
@@ -719,16 +719,37 @@ def add_config_entries(
 # Saving related functions
 # -------------------------------------------------------------------------
 
+def save_df_and_info(df: DataFrame, plot_info: dict) -> dict:
+    """Returns a dictionary containing a dataframe for the parameter(s) under study for a given subsystem. The plotting info are saved too."""
+    par_dict_content = {
+        "df_" + plot_info["subsystem"]: df, # saving dataframe
+        "plot_info": plot_info # saving plotting info
+    }
+
+    return par_dict_content
+
 
 def build_out_dict(
     plot_settings: list,
-    plot_info: list,
     par_dict_content: dict,
     out_dict: dict,
-    saving: str,
-    plt_path: str,
 ):
-    """Build the output dictionary based on the input 'saving' option."""
+    """
+    Build the output dictionary based on the input 'saving' option.
+    
+    Parameters
+    ----------
+    plot_settings
+        Dictionary with settings for plotting. It contains the following keys: 'parameters', 'event_type', 'plot_structure', 'resampled', 'plot_style', 'variation', 'time_window', 'range', 'saving', 'plt_path'
+    par_dict_content
+        Dictionary containing, for a given parameter, the dataframe with data and a dictionary with info for plotting (e.g. plot style, title, units, labels, ...)
+    out_dict
+        Dictionary that is returned, containing the objects that need to be saved. 
+    """
+    saving = plot_settings['saving'] if 'saving' in plot_settings.keys() else None
+    plt_path = plot_settings['plt_path'] if 'plt_path' in plot_settings.keys() else None
+    plot_info = par_dict_content['plot_info'] 
+
     # we overwrite the object with a new one
     if saving == "overwrite":
         out_dict = save_dict(plot_settings, plot_info, par_dict_content, out_dict)
@@ -794,22 +815,78 @@ def save_dict(
     plot_settings: list, plot_info: list, par_dict_content: dict, out_dict: dict
 ):
     """Create a dictionary with the correct format for being saved in the final shelve object."""
-    parameter = (
-        plot_info["parameter"].split("_var")[0]
-        if "_var" in plot_info["parameter"]
-        else plot_info["parameter"]
-    )
-    # event type key is already there
-    if plot_settings["event_type"] in out_dict.keys():
-        out_dict[plot_settings["event_type"]][parameter] = par_dict_content
-    # event type key is NOT there
-    else:
-        # empty dictionary (not filled yet)
-        if len(out_dict.keys()) == 0:
-            out_dict = {plot_settings["event_type"]: {parameter: par_dict_content}}
-        # the dictionary already contains something (but for another event type selection)
+    # get the parameters under study (can be one, can be more for 'par vs par' plot style)
+    params = plot_info["parameters"]
+
+    # one parameter
+    if len(params) == 1:
+        parameter = (
+            plot_info["parameter"].split("_var")[0]
+            if "_var" in plot_info["parameter"]
+            else plot_info["parameter"]
+        )
+        # --- building up the output dictionary
+        # event type key is already there
+        if plot_settings["event_type"] in out_dict.keys():
+            out_dict[plot_settings["event_type"]][parameter] = par_dict_content
+        # event type key is NOT there
         else:
-            out_dict[plot_settings["event_type"]] = {parameter: par_dict_content}
+            # empty dictionary (not filled yet)
+            if len(out_dict.keys()) == 0:
+                out_dict = {plot_settings["event_type"]: {parameter: par_dict_content}}
+            # the dictionary already contains something (but for another event type selection)
+            else:
+                out_dict[plot_settings["event_type"]] = {parameter: par_dict_content}
+    # more than one parameter
+    else:
+        # some info we'll later need to better divide the parameters stored in the dataframe...
+        keep_cols = ['index', 'channel', 'HV_card', 'HV_channel', 'cc4_channel', 'cc4_id', 'daq_card', 'daq_crate', 'datetime', 'det_type', 'flag_fc_bsln', 'flag_muon', 'flag_pulser', 'location', 'name', 'position', 'status']
+        keep_keys = ['subsystem', 'locname', 'plot_style', 'time_window', 'resampled', 'range', 'std']
+        new_keys = ['unit', 'label', 'unit_label', 'parameters', 'param_mean']
+
+        for param in params:
+            parameter = (
+                param.split("_var")[0]
+                if "_var" in param
+                else param
+            )
+
+            # we have to polish our dataframe and plot_info dictionary from other parameters...
+            # --- original objects 
+            plot_info_all = par_dict_content["plot_info"]
+            df_all = par_dict_content["df_" + plot_info_all["subsystem"]]
+
+            #  --- cleaned plot_info
+            plot_info_param = {key: plot_info_all[key] for key in keep_keys}
+            # set a default title - that does not involve a second parameter in it
+            plot_info_param['title'] = f"Plotting {param}"
+            for new_key in new_keys:
+                obj = plot_info_all[new_key]
+                if isinstance(obj, dict):
+                    plot_info_param[new_key] = [v for k,v in obj.items() if parameter in k][0]
+                if isinstance(obj, list):
+                    plot_info_param[new_key] = [k for k in obj if parameter in k][0]
+
+            # --- cleaned df
+            df_param = df_all.copy().drop(columns={x for x in df_all.columns if parameter not in x})
+            df_cols = df_all.copy().drop(columns={x for x in df_all.columns if x not in keep_cols})
+            df_param = concat([df_param, df_cols], axis=1)
+
+            # --- rebuilding the 'par_dict_content' for the parameter under study
+            par_dict_content = save_df_and_info(df_param, plot_info_param)
+
+            # --- building up the output dictionary
+            # event type key is already there
+            if plot_settings["event_type"] in out_dict.keys():
+                out_dict[plot_settings["event_type"]][parameter] = par_dict_content
+            # event type key is NOT there
+            else:
+                # empty dictionary (not filled yet)
+                if len(out_dict.keys()) == 0:
+                    out_dict = {plot_settings["event_type"]: {parameter: par_dict_content}}
+                # the dictionary already contains something (but for another event type selection)
+                else:
+                    out_dict[plot_settings["event_type"]] = {parameter: par_dict_content}
 
     return out_dict
 


### PR DESCRIPTION
Now, you can specifiy ```"saving": "overwrite"``` in your config json file and the code does not crash anymore.

Since the building of the output shelve object reads the dataframe/plot_info objects containing both par1 and par2 data/info, it was necessary to loop over individual parameters and separate the dataframe/plot_info objects.

Then, output shelve object now looks like (as if we inspected the two parameters separately - this helps us, in a second stage, to play more easily with the stored output dataframes):

``` bash
<shelve-object>
└── "monitoring"
    └── "<evt_type>" // can be: pulser, phy, all, FC_bsln, muon, ...
      └── "<par1>"
      ├ ├── df_<subsystem> // eg. "df_geds" = dataframe with data for all ged channels
      ├ └── plot_info // dictionary with plotting info for the given parameter (eg. title, units, labels, ...)
      └── "<par2>"
        ├── df_<subsystem> 
        └── plot_info 
```