### PR TITLE
fixed append option and added bunch option for long time windows

### DIFF
--- a/src/legend_data_monitor/analysis_data.py
+++ b/src/legend_data_monitor/analysis_data.py
@@ -447,6 +447,7 @@ class AnalysisData:
                             # we need to repeat this operation for each param, otherwise only the mean of the last one survives
                             self.data = concat_channel_mean(self, channel_mean)
 
+
     def calculate_variation(self):
         """
         Add a new column containing the percentage variation of a given parameter.
@@ -610,6 +611,7 @@ def get_aux_df(
             and utils.PARAMETER_TIERS[param] == "hit"
         ) or param in utils.SPECIAL_PARAMETERS.keys():
             return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+
         # get abs/mean/% variation for data of aux channel --> objects to save
         utils.logger.debug(f"Getting {aux_ch} data for {param}")
         aux_data = df.copy()
@@ -621,6 +623,27 @@ def get_aux_df(
                 f"{param}_{aux_ch}Diff",
             ]
         )
+        # right now, we have the same values repeated for each ged channel 
+        # -> keep one and substytute with AUX channel ID
+        # (only for this aux df, the others still maintain a relation with geds values)
+        # keep one channel only
+        first_ch = aux_data.iloc[0]["channel"]
+        aux_data = aux_data[aux_data["channel"] == first_ch]
+        first_timestamp = utils.unix_timestamp_to_string(
+            aux_data["datetime"].dt.to_pydatetime()[0].timestamp()
+        )
+        if aux_ch == "pulser01ana":
+            chmap = LegendMetadata().hardware.configuration.channelmaps.on(
+                timestamp=first_timestamp
+            )
+            # PULS01ANA channel
+            if "PULS01ANA" in chmap.keys():
+                aux_data = get_aux_info(aux_data, chmap, "PULS01ANA")
+            # PULS (=AUX00) channel (for periods below p03)
+            else:
+                aux_data = get_aux_info(aux_data, chmap, "PULS01")
+
+        # get channel mean and blabla
         aux_analysis = AnalysisData(aux_data, selection=plot_settings)
         utils.logger.debug(aux_analysis.data)
 
@@ -664,6 +687,22 @@ def get_aux_df(
 
     return aux_analysis, aux_ratio_analysis, aux_diff_analysis
 
+
+def get_aux_info(df: pd.DataFrame, chmap: dict, aux_ch: str) -> pd.DataFrame:
+    """Return a DataFrame with correct pulser AUX info."""
+    df["channel"] = LegendMetadata().channelmap().PULS01ANA.daq.rawid
+    df["HV_card"] = None
+    df["HV_channel"] = None
+    df["cc4_channel"] = None
+    df["cc4_id"] = None
+    df["daq_card"] = LegendMetadata().channelmap().PULS01ANA.daq.card.id
+    df["daq_crate"] = LegendMetadata().channelmap().PULS01ANA.daq.crate
+    df["det_type"] = None
+    df["location"] = utils.SPECIAL_SYSTEMS["pulser01ana"] if aux_ch == "PULS01ANA" else utils.SPECIAL_SYSTEMS["pulser"]
+    df["position"] = df["location"]
+    df["name"] = aux_ch
+
+    return df
 
 def concat_channel_mean(self, channel_mean) -> pd.DataFrame:
     """Add a new column containing the mean values of the inspected parameter."""

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -327,12 +327,13 @@ def make_subsystem_plots(
         # --- save shelf
         # normal geds values (??? do we want the rescaled ones to be saved as shelf?)
         par_dict_content = save_data.save_df_and_info(data_analysis.data, plot_info)
-        # aux values as shelf (necessary to get the right mean)
-        aux_plot_info = plot_info.copy()
-        aux_plot_info["subsystem"] = "pulser01ana"
-        aux_par_dict_content = save_data.save_df_and_info(
-            aux_analysis.data, aux_plot_info
-        )
+        # aux values as shelf (necessary to get the right mean) - if not empty
+        if not utils.check_empty_df(aux_analysis):
+            aux_plot_info = plot_info.copy()
+            aux_plot_info["subsystem"] = "pulser01ana"
+            aux_par_dict_content = save_data.save_df_and_info(
+                aux_analysis.data, aux_plot_info
+            )
         # --- save hdf
         save_data.save_hdf(
             saving,
@@ -378,7 +379,7 @@ def make_subsystem_plots(
                 plot_settings, par_dict_content, out_dict
             )
             # check if aux is empty or not
-            if not utils.check_empty_df(aux_analysis.data):
+            if not utils.check_empty_df(aux_analysis):
                 aux_out_dict = save_data.build_out_dict(
                     plot_settings, aux_par_dict_content, aux_out_dict
                 )
@@ -390,7 +391,7 @@ def make_subsystem_plots(
         out_file.close()
 
         # check if aux is empty or not
-        if not utils.check_empty_df(aux_analysis.data):
+        if not utils.check_empty_df(aux_analysis):
             aux_out_file = shelve.open(plt_path + "-pulser01ana")
             aux_out_file["monitoring"] = aux_out_dict
             aux_out_file.close()

--- a/src/legend_data_monitor/plotting.py
+++ b/src/legend_data_monitor/plotting.py
@@ -37,6 +37,7 @@ def make_subsystem_plots(
 ):
     pdf = PdfPages(plt_path + "-" + subsystem.type + ".pdf")
     out_dict = {}
+    aux_out_dict = {}
 
     for plot_title in plots:
         utils.logger.info(
@@ -326,6 +327,12 @@ def make_subsystem_plots(
         # --- save shelf
         # normal geds values (??? do we want the rescaled ones to be saved as shelf?)
         par_dict_content = save_data.save_df_and_info(data_analysis.data, plot_info)
+        # aux values as shelf (necessary to get the right mean)
+        aux_plot_info = plot_info.copy()
+        aux_plot_info["subsystem"] = "pulser01ana"
+        aux_par_dict_content = save_data.save_df_and_info(
+            aux_analysis.data, aux_plot_info
+        )
         # --- save hdf
         save_data.save_hdf(
             saving,
@@ -370,12 +377,23 @@ def make_subsystem_plots(
             out_dict = save_data.build_out_dict(
                 plot_settings, par_dict_content, out_dict
             )
+            # check if aux is empty or not
+            if not utils.check_empty_df(aux_analysis.data):
+                aux_out_dict = save_data.build_out_dict(
+                    plot_settings, aux_par_dict_content, aux_out_dict
+                )
 
     # save in shelve object, overwriting the already existing file with new content (either completely new or new bunches)
     if saving is not None:
         out_file = shelve.open(plt_path + f"-{subsystem.type}")
         out_file["monitoring"] = out_dict
         out_file.close()
+
+        # check if aux is empty or not
+        if not utils.check_empty_df(aux_analysis.data):
+            aux_out_file = shelve.open(plt_path + "-pulser01ana")
+            aux_out_file["monitoring"] = aux_out_dict
+            aux_out_file.close()
 
     # save in pdf object
     pdf.close()

--- a/src/legend_data_monitor/run.py
+++ b/src/legend_data_monitor/run.py
@@ -68,6 +68,7 @@ def main():
 
     # functions for different purpouses
     add_user_config_parser(subparsers)
+    add_user_bunch_parser(subparsers)
     add_user_rsync_parser(subparsers)
     add_auto_prod_parser(subparsers)
 
@@ -106,6 +107,34 @@ def user_config_cli(args):
 
     # start loading data & generating plots
     legend_data_monitor.core.control_plots(config_file)
+
+
+def add_user_bunch_parser(subparsers):
+    """Configure :func:`.core.control_plots` command line interface."""
+    parser_auto_prod = subparsers.add_parser(
+        "user_bunch",
+        description="""Inspect LEGEND HDF5 (LH5) processed data by giving a full config file with parameters/subsystems info to plot. Files will be bunched in groups of n_files files each, and every time the code is run you will append new data to the previously generated ones.""",
+    )
+    parser_auto_prod.add_argument(
+        "--config",
+        help="""Path to config file (e.g. \"some_path/config_L200_r001_phy.json\").""",
+    )
+    parser_auto_prod.add_argument(
+        "--n_files",
+        help="""Number (int) of files of a given run you want to inspect at each cycle.""",
+    )
+    parser_auto_prod.set_defaults(func=user_bunch_cli)
+
+
+def user_bunch_cli(args):
+    """Pass command line arguments to :func:`.core.control_plots`."""
+    # get the path to the user config file
+    config_file = args.config
+    # get the number of files for each cycle
+    n_files = args.n_files
+
+    # start loading data & generating plots
+    legend_data_monitor.core.control_plots(config_file, n_files)
 
 
 def add_user_rsync_parser(subparsers):

--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -410,6 +410,10 @@ class Subsystem:
         else:
             # --- if no object was provided, it's understood that this itself is a pulser
             # find timestamps over threshold
+            # if self.below_period_3_excluded():
+            #    high_thr = 12500
+            # if self.above_period_3_included():
+            #    high_thr = 2500
             high_thr = 12500
             self.data = self.data.set_index("datetime")
             wf_max_rel = self.data["wf_max"] - self.data["baseline"]
@@ -549,11 +553,14 @@ class Subsystem:
                 if self.experiment == "L60":
                     return entry["system"] == "auxs" and entry["daq"]["fcid"] == 0
                 if self.experiment == "L200":
+                    # we get PULS01
                     if self.below_period_3_excluded():
                         return entry["system"] == "puls" and entry["daq"][ch_flag] == 1
+                    # we get PULS01ANA
                     if self.above_period_3_included():
                         return (
                             entry["system"] == "puls"
+                            # and entry["daq"][ch_flag] == 1027203
                             and entry["daq"][ch_flag] == 1027201
                         )
             # special case for pulser AUX
@@ -605,7 +612,7 @@ class Subsystem:
         type_code = {"B": "bege", "C": "coax", "V": "icpc", "P": "ppc"}
 
         # systems for which the location/position has to be handled carefully; values were chosen arbitrarily to avoid conflicts
-        special_systems = {"pulser": 0, "pulser01ana": -1, "FCbsln": -2, "muon": -3}
+        special_systems = utils.SPECIAL_SYSTEMS
 
         # -------------------------------------------------------------------------
         # loop over entries and find out subsystem
@@ -739,7 +746,7 @@ class Subsystem:
         # --- always read timestamp
         params = ["timestamp"]
         # --- always get wf_max & baseline for pulser for flagging
-        if self.type in ["pulser", "FCbsln", "muon"]:
+        if self.type in ["pulser", "pulser01ana", "FCbsln", "muon"]:
             params += ["wf_max", "baseline"]
 
         # --- add user requested parameters


### PR DESCRIPTION
# Fixed append option
Before, there were problems when 1) loading the old mean and update it with the new value for the aux system (solved by saving the shelf object for the aux channel - the mean is retrieved from there) 2) appending new data, because the % variations of the previous inspected time window were not updated with the new mean evaluated over the newer and longer time window (this was fixed both in shelf and hdf files)

# Added bunch option for long time windows
It already happened that LNGS resources are not enough to produce these plots if a large time window was selected. The idea is, provided a given start+end date/run/list of timestamps in the config file, we can use the following terminal command
``` bash
~/.local/bin/legend-data-monitor  user_bunch --config path_to_config/config.json --n_files 30
```
to subdivide the analysis, inspecting `n_files` per loop. 

Indded, suppose you want to inspect p03-r000: in this way, you start by inspecting the first 30 files (ordered by timestamp), then you switch to study the next 30 files and append new data to the previous data (re-evaluating means over the larger time window and refreshing the old % variations with the new mean), and so and so on, until there are no more files from that run to inspect. This automatize the process of subdividing long time windows by hand.